### PR TITLE
Fix publisher class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## 1.0.0-alpha.13
 
 - Fix `Publisher` class.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Fix `Publisher` class.
+
 ## 1.0.0-alpha.12
 
 - Added `Logger` instance to the common folder.

--- a/idearium-lib/common/mq/publisher.js
+++ b/idearium-lib/common/mq/publisher.js
@@ -16,7 +16,7 @@ class Publisher {
      * @param {Object} data Message data.
      * @return {Void} Publishes the message.
      */
-    static publish (type, data) {
+    publish (type, data) {
 
         if (!hasProperty(this.messagesPath, type)) {
             return log.error(`Message of type: ${type} not found`);
@@ -31,4 +31,4 @@ class Publisher {
 
 }
 
-module.exports = messagesPath => new Publisher(messagesPath);
+module.exports = Publisher;

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
@patelswapnil Quick one for you to approve.

There was a bug preventing the publisher from working in the recent release, this fixes that and you can use it as per below:

```
'use strict';

const Publisher = require('@idearium/idearium-lib/common/mq/publisher');
const publisher = new Publisher('../messages');

module.exports = publisher;
```