### PR TITLE
Add MandrillEmail class to common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is a history of the changes made to idearium-lib.
 ## Unreleased
 
 - Add `MandrillEmail` to common.
+- Replace `kue.process` with `kue.processJobs`. This now automates processing all jobs in the `jobs` directory.
 
 ## 1.0.0-alpha.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Add `MandrillEmail` to common.
+
 ## 1.0.0-alpha.14
 
 - Simplified `common/exception` now that Opbeat should become standard practice.

--- a/idearium-lib/common/kue.js
+++ b/idearium-lib/common/kue.js
@@ -2,6 +2,12 @@
 
 const log = require('./log')('idearium-lib:common:kue');
 const kueQueue = require('./kue-queue');
+const path = require('path');
+const { Loader } = require('../');
+
+// Setup the loader.
+const loader = new Loader();
+loader.camelCase = false;
 
 /**
  * Verify and create a factory method for creating kue jobs.
@@ -61,19 +67,48 @@ const constructCreateMethod = (type, properties) => {
 };
 
 /**
- * Helper function to process Kue jobs.
- * @param {String} type Job type to process.
- * @param {Function} fn Queue process callback.
- * @return {Void} Processes the job.
+ * Load jobs from the jobs directory.
+ * @return {Promise} Resolves with the jobs.
  */
-const process = (type, fn) => kueQueue.process(type, (job, done) => {
+const loadJobs = () => loader.load(path.join(process.cwd(), 'jobs'));
 
-    log.debug({ job, type }, `Processing job with type ${type}`);
+/**
+ * Process all jobs in the jobs directory.
+ * @return {Void} Processes the jobs.
+ */
+const processJobs = () => new Promise((resolve, reject) => {
 
-    fn(job)
-        .then(data => done(null, data))
-        .catch(done);
+    loadJobs()
+        .then((jobs) => {
+
+            const jobKeys = Object.keys(jobs);
+
+            // An array of job process functions.
+            const jobProcesses = jobKeys.map((type) => new Promise((resolve, reject) => {
+
+                kueQueue.process(type, (job, done) => {
+
+                    log.debug({ job, type }, `Processing job with type ${type}`);
+
+                    const fn = jobs[type];
+
+                    log.debug({ fn }, 'Calling function');
+
+                    fn(job)
+                        .then(data => resolve(done(null, data)))
+                        .catch(err => reject(done(err)));
+
+                });
+
+            }));
+
+            // Process the jobs.
+            return Promise.all(jobProcesses);
+
+        })
+        .then(resolve)
+        .catch(reject);
 
 });
 
-module.exports = { constructCreateMethod, process };
+module.exports = { constructCreateMethod, processJobs };

--- a/idearium-lib/common/mandrill-email.js
+++ b/idearium-lib/common/mandrill-email.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const config = require('./config');
+const lib = require('../');
+const log = require('./log')('idearium-lib:common/mandrill-email');
+
+class MandrillEmail extends lib.Email {
+
+    constructor () {
+
+        if (!config.get('mandrillAPIKey')) {
+            throw new Error('"mandrillAPIKey" config is not defined.');
+        }
+
+        super(config.get('mandrillAPIKey'), lib.emailServices.Mandrill);
+
+    }
+
+    send (message, cb) {
+
+        // Set default fromEmail.
+        message.fromEmail = message.fromEmail || config.get('fromEmail');
+
+        // Execute `send` on the super class.
+        super.send(message, (err, result) => {
+
+            log.info('Sent %d emails for %s via Mandrill.', message.to.length, message.subject);
+
+            // Remove html content as we don't need it in the log.
+            delete message.html;
+
+            if (err) {
+
+                log.error({ err, message }, 'Error sending email via Mandrill');
+
+                return cb(err);
+
+            }
+
+            const errors = [];
+
+            result.forEach((obj) => {
+
+                if (obj.status === 'rejected' || obj.status === 'invalid') {
+                    errors.push(obj);
+                }
+
+            });
+
+            if (errors.length) {
+
+                log.error({ err: errors, message }, 'Some of the emails failed to send via Mandrill');
+
+            }
+
+            return cb(null, result);
+
+        });
+
+    }
+
+}
+
+module.exports = MandrillEmail;

--- a/idearium-lib/common/mandrill-email.js
+++ b/idearium-lib/common/mandrill-email.js
@@ -48,9 +48,7 @@ class MandrillEmail extends lib.Email {
             });
 
             if (errors.length) {
-
                 log.error({ err: errors, message }, 'Some of the emails failed to send via Mandrill');
-
             }
 
             return cb(null, result);


### PR DESCRIPTION
This PR adds the MandrillEmail class to common and replaces `kue.process` with `kue.processJobs`.

## Notes

- There are no tests for this class.