### PR TITLE
Improve the query functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Refactored the query methods to allow all query `conditions` and `options`. i.e. you can now pass in `limit` through the `options` object rather than adding a query chain method `.limit()`.
+
 ## 1.0.0-alpha.19
 
-- Add the `common/crypto` library, and tests.
+- Add the `common/crypto` library, and tests.- Add the `common/crypto` library, and tests.
+
 
 ## 1.0.0-alpha.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ This file is a history of the changes made to idearium-lib.
 
 ## 1.0.0-alpha.19
 
-- Add the `common/crypto` library, and tests.- Add the `common/crypto` library, and tests.
-
+- Add the `common/crypto` library, and tests.
 
 ## 1.0.0-alpha.18
 

--- a/idearium-lib/lib/query.js
+++ b/idearium-lib/lib/query.js
@@ -23,7 +23,7 @@ const getOptions = (options) => {
         filter: {},
         lean: true,
         limit: 10,
-        projection: '',
+        projection: '_id',
     };
 
     Object.assign(defaults, options);
@@ -42,25 +42,19 @@ const getOptions = (options) => {
  * @example
  * query.find(UserModel, {
  *     filter: { _id: id },
- *     lean: false, // Defaults to true
- *     limit: 5, // Defaults to 10
  *     projection: 'email username', // _id is always returned
  * });
  * @param {Object} model Mongoose model.
  * @param {Object} options Mongoose query options.
  * @param {Object} options.filter Mongo query filters.
- * @param {Boolean} options.lean Whether to return a plain JavaScript object or not.
- * @param {Number} options.limit Number of documents to return.
  * @param {String} options.projection Space delimited string containing the fields to return or '*' to return all fields.
  * @return {Promise} Returns a Mongoose query.
  */
 const find = (model, options) => {
 
-    const { filter, lean, limit, projection } = getOptions(options);
+    const { filter, projection } = getOptions(options);
 
-    return model.find(filter, projection)
-        .lean(lean)
-        .limit(limit);
+    return model.find(filter, projection, getOptions(options));
 
 };
 
@@ -69,22 +63,19 @@ const find = (model, options) => {
  * @example
  * query.findOne(UserModel, {
  *     filter: { _id: id },
- *     lean: false, // Defaults to true
  *     projection: 'email username', // _id is always returned
  * });
  * @param {Object} model Mongoose model.
  * @param {Object} options Mongoose query options.
  * @param {Object} options.filter Mongo query filters.
- * @param {Boolean} options.lean Whether to return a plain JavaScript object or not.
- * @param {String} options.projection Space delimited string containing the fields to return.
+ * @param {String} options.projection Space delimited string containing the fields to return or '*' to return all fields.
  * @return {Promise} Returns a Mongoose query.
  */
 const findOne = (model, options) => {
 
-    const { filter, lean, projection } = getOptions(options);
+    const { filter, projection } = getOptions(options);
 
-    return model.findOne(filter, projection)
-        .lean(lean);
+    return model.findOne(filter, projection, getOptions(options));
 
 };
 

--- a/idearium-lib/test/query.js
+++ b/idearium-lib/test/query.js
@@ -24,7 +24,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.all.keys('email', 'username');
+        expect(_fields).to.have.keys('email', 'username');
         expect(options.limit).to.equal(20);
 
     });
@@ -41,7 +41,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.all.keys('email', 'username');
+        expect(_fields).to.have.keys('email', 'username');
         expect(options.limit).to.equal(10);
 
     });
@@ -57,7 +57,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.all.keys('email', 'username');
+        expect(_fields).to.have.keys('email', 'username');
         expect(options.limit).to.equal(10);
 
     });
@@ -72,7 +72,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.be.undefined;
+        expect(_fields).to.have.keys('_id');
         expect(options.limit).to.equal(10);
 
     });
@@ -89,7 +89,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.all.keys('email', 'username');
+        expect(_fields).to.have.keys('email', 'username');
 
     });
 
@@ -104,7 +104,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.all.keys('email', 'username');
+        expect(_fields).to.have.keys('email', 'username');
 
     });
 
@@ -118,7 +118,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.be.undefined;
+        expect(_fields).to.have.keys('_id');
 
     });
 

--- a/idearium-lib/test/query.js
+++ b/idearium-lib/test/query.js
@@ -24,7 +24,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.keys('email', 'username');
+        expect(_fields).to.have.all.keys('email', 'username');
         expect(options.limit).to.equal(20);
 
     });
@@ -41,7 +41,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.keys('email', 'username');
+        expect(_fields).to.have.all.keys('email', 'username');
         expect(options.limit).to.equal(10);
 
     });
@@ -57,7 +57,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.keys('email', 'username');
+        expect(_fields).to.have.all.keys('email', 'username');
         expect(options.limit).to.equal(10);
 
     });
@@ -72,7 +72,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.keys('_id');
+        expect(_fields).to.have.all.keys('_id');
         expect(options.limit).to.equal(10);
 
     });
@@ -89,7 +89,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(false);
-        expect(_fields).to.have.keys('email', 'username');
+        expect(_fields).to.have.all.keys('email', 'username');
 
     });
 
@@ -104,7 +104,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.keys('email', 'username');
+        expect(_fields).to.have.all.keys('email', 'username');
 
     });
 
@@ -118,7 +118,7 @@ describe('query', function () {
 
         expect(_conditions._id.toString()).to.equal('5938a0aefb6e41e0e8368d00');
         expect(_mongooseOptions.lean).to.equal(true);
-        expect(_fields).to.have.keys('_id');
+        expect(_fields).to.have.all.keys('_id');
 
     });
 


### PR DESCRIPTION
Quick one to improve the query functions.

Instead of creating a new function for when you do and don't want chainable options
```javascript
const findOneData = options => new Promise((resolve, reject) => {

    const Data = linz.mongoose.model('data');

    findOne(Data, options)
        .populate('field')
        .limit(100)
        .then(resolve)
        .catch(reject);

});

findOneData({});
```

You can now add them in the query options.
```javascript
const findOneData = options => new Promise((resolve, reject) => {

    const Data = linz.mongoose.model('data');

    findOne(Data, options)
        .then(resolve)
        .catch(reject);

});

findOneData({ limit: 100, populate: 'field' });
```