### PR TITLE
Fixed a typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Fixed a typo in `mq.connection`. Changed `Promise.resolved` to `Promise.resolve`. Added a test case specific for this.
+
 ## 1.0.0-alpha.20
 
 - Refactored the query methods to allow all query `conditions` and `options`. i.e. you can now pass in `limit` through the `options` object rather than adding a query chain method `.limit()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## 1.0.0-alpha.21
 
 - Fixed a typo in `mq.connection`. Changed `Promise.resolved` to `Promise.resolve`. Added a test case specific for this.
 

--- a/idearium-lib/lib/mq/connection.js
+++ b/idearium-lib/lib/mq/connection.js
@@ -117,7 +117,7 @@ class Connection extends EventEmitter {
 
         // Don't attempt if we don't have a connection.
         if (!this.connection) {
-            return Promise.resolved();
+            return Promise.resolve();
         }
 
         debug('Disconnecting...');

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.21",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {

--- a/idearium-lib/test/lib-mq-connection.js
+++ b/idearium-lib/test/lib-mq-connection.js
@@ -58,7 +58,18 @@ describe('class mq.Connection', function () {
 
     describe('gracefully disconnects', function () {
 
-        it('RabbitMQ', function (done) {
+        it('when not connected', function (done) {
+
+            // Setup an instance of the class.
+            const ideariumMq = new mq.Connection(conf.rabbitUrl);
+
+            ideariumMq.disconnect()
+                .then(done)
+                .catch(done);
+
+        });
+
+        it('from RabbitMQ', function (done) {
 
             this.timeout(10000);
 

--- a/idearium-lib/test/lib-mq-connection.js
+++ b/idearium-lib/test/lib-mq-connection.js
@@ -64,7 +64,7 @@ describe('class mq.Connection', function () {
             const ideariumMq = new mq.Connection(conf.rabbitUrl);
 
             ideariumMq.disconnect()
-                .then(done)
+                .then(() => done())
                 .catch(done);
 
         });


### PR DESCRIPTION
The `mq.connection` class had a typo. I've changed `Promise.resolved` to `Promise.resolve`. There is a new unit test specific for this test case (executing `disconnect` when in a disconnected state).

I'd like to push this PR ahead of the rest, so that I can resolve the current issue with have with one of our projects.