### PR TITLE
WIP: Publish promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## 1.0.0-alpha.22
 
 - Update `mq.Manager().publish` to pass on a `Promise` if one was returned from the `message.publish` function, otherwise return `Promise.resolve()` by default.
 - Update `mq.Client().publish` to return a `Promise`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This file is a history of the changes made to idearium-lib.
 
 ## Unreleased
 
-- Update `(new mq.Manager()).publish` to pass on a `Promise` if one was returned from the `message.publish` function, otherwise return `Promise.resolve()` by default.
+- Update `mq.Manager().publish` to pass on a `Promise` if one was returned from the `message.publish` function, otherwise return `Promise.resolve()` by default.
+- Update `mq.Client().publish` to return a `Promise`.
+- Update `common/mq/publisher` to return a `Promise`.
 
 ## 1.0.0-alpha.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Update `(new mq.Manager()).publish` to pass on a `Promise` if one was returned from the `message.publish` function, otherwise return `Promise.resolve()` by default.
+
 ## 1.0.0-alpha.21
 
 - Fixed a typo in `mq.connection`. Changed `Promise.resolved` to `Promise.resolve`. Added a test case specific for this.

--- a/idearium-lib/common/mq/publisher.js
+++ b/idearium-lib/common/mq/publisher.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const manager = require('./messages');
-const { hasProperty } = require('../../lib/util');
 const log = require('../log')('idearium-lib:common:mq/publisher');
 
 /**
@@ -12,15 +11,13 @@ const log = require('../log')('idearium-lib:common:mq/publisher');
  */
 const publish = (type, data) => {
 
-    if (!hasProperty(manager.messages, type)) {
-        return log.error(`Message of type: ${type} not found`);
-    }
+    return manager.publish(type, data)
+        .then(() => {
 
-    log.debug({ data, type }, `Publishing message of type: ${type}`);
+            log.debug({ data, type }, `Publishing message of type: ${type}`);
 
-    // Publish the message (returning a Promise).
-    return manager.messages[type].publish(data);
+        });
 
-}
+};
 
 module.exports = publish;

--- a/idearium-lib/common/mq/publisher.js
+++ b/idearium-lib/common/mq/publisher.js
@@ -8,7 +8,7 @@ const log = require('../log')('idearium-lib:common:mq/publisher');
  * Check if a RabbitMQ message exists before publishing.
  * @param {String} type Message type.
  * @param {Object} data Message data.
- * @return {Void} Publishes the message.
+ * @return {Promise} Publishes the message.
  */
 const publish = (type, data) => {
 
@@ -16,10 +16,10 @@ const publish = (type, data) => {
         return log.error(`Message of type: ${type} not found`);
     }
 
-    // Publish the message.
-    manager.messages[type].publish(data);
+    log.debug({ data, type }, `Publishing message of type: ${type}`);
 
-    return log.debug({ data, type }, `Publishing message of type: ${type}`);
+    // Publish the message (returning a Promise).
+    return manager.messages[type].publish(data);
 
 }
 

--- a/idearium-lib/lib/mq/client.js
+++ b/idearium-lib/lib/mq/client.js
@@ -128,23 +128,31 @@ class Client extends Connection {
     /**
      * Add a message to publisher queue
      * @param  {Function} fn Publisher function
+     * @returns {Promise} A promise that will be resolved or rejected.
      */
-    publish(fn) {
+    publish (fn) {
 
-        this.publisherQueue.push(fn, (err) => {
+        /* eslint-disable padded-blocks */
+        if (!this.connection) {
+            this.connect();
+        }
+        /* eslint-enable padded-blocks */
 
-            if (err) {
-                this.logError(err);
-                debug('Unable to register a publisher, re-queue publisher in ' + this.queueTimeout / 1000 + 's');
-                // re-queue in 5 seconds
-                setTimeout(() => { this.publish(fn); }, this.queueTimeout);
-            }
+        return new Promise((resolve, reject) => {
+
+            this.publisherQueue.push(fn, (err, ...args) => {
+
+                /* eslint-disable padded-blocks */
+                if (err) {
+                    reject(err);
+                }
+                /* eslint-enable padded-blocks */
+
+                resolve(...args);
+
+            });
 
         });
-
-        if (!this.connection) {
-            return this.connect();
-        }
 
     }
 

--- a/idearium-lib/lib/mq/client.js
+++ b/idearium-lib/lib/mq/client.js
@@ -144,11 +144,11 @@ class Client extends Connection {
 
                 /* eslint-disable padded-blocks */
                 if (err) {
-                    reject(err);
+                    return reject(err);
                 }
                 /* eslint-enable padded-blocks */
 
-                resolve(...args);
+                return resolve(...args);
 
             });
 

--- a/idearium-lib/lib/mq/manager.js
+++ b/idearium-lib/lib/mq/manager.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-    Loader = require('../loader');
+const { EventEmitter } = require('events');
+const Loader = require('../loader');
 
 class Manager extends EventEmitter {
 
-    constructor(path) {
+    constructor (path) {
 
+        /* eslint-disable padded-blocks */
         if (!path) {
             throw new Error('The path parameter is required');
         }
+        /* eslint-enable padded-blocks */
 
         // Instantiate super class.
         super();
@@ -44,14 +46,17 @@ class Manager extends EventEmitter {
      * Return an instance of the Loader class, configured as required.
      * @return {Loader} An instance of the Loader class.
      */
+    // eslint-disable-next-line no-restricted-syntax
     get loader () {
 
-        if (!this._loader) {
-            this._loader = new Loader();
-            this._loader.camelCase = false;
+        if (!this.loaderInstance) {
+
+            this.loaderInstance = new Loader();
+            this.loaderInstance.camelCase = false;
+
         }
 
-        return this._loader;
+        return this.loaderInstance;
 
     }
 
@@ -59,11 +64,12 @@ class Manager extends EventEmitter {
      * Register message queue consumers
      * @return {[type]} [description]
      */
-    registerConsumers() {
+    registerConsumers () {
 
-        var messages = this.messages;
+        const { messages } = this;
 
         return Promise.all(Object.keys(messages)
+            // eslint-disable-next-line no-undefined
             .filter(messageName => messages[messageName].consume !== undefined)
             .map(messageName => messages[messageName].consume()));
 
@@ -74,18 +80,34 @@ class Manager extends EventEmitter {
      * @param  {String} messageName Message name (should match the name of the message file)
      * @return {[type]}             [description]
      */
-    publish(messageName) {
+    publish (messageName) {
 
+        /* eslint-disable padded-blocks */
         if (!this.messages[messageName]) {
             throw new Error(`"${messageName}" message is not defined.`);
         }
+        /* eslint-enable padded-blocks */
 
+        /* eslint-disable padded-blocks */
         if (!this.messages[messageName].publish) {
             return;
         }
+        /* eslint-enable padded-blocks */
 
         // Remove first argument and publish.
-        this.messages[messageName].publish.apply(this, [].slice.call(arguments).slice(1));
+        // eslint-disable-next-line prefer-rest-params
+        const argsArray = [].slice.call(arguments).slice(1);
+        const result = this.messages[messageName].publish.apply(this, argsArray);
+
+        // If a promise is returned by the messages publish function, return it.
+        /* eslint-disable padded-blocks */
+        if (result instanceof Promise) {
+            return result;
+        }
+        /* eslint-enable padded-blocks */
+
+        // Otherwise, assume everything went okay.
+        return Promise.resolve();
 
     }
 

--- a/idearium-lib/lib/mq/manager.js
+++ b/idearium-lib/lib/mq/manager.js
@@ -69,8 +69,7 @@ class Manager extends EventEmitter {
         const { messages } = this;
 
         return Promise.all(Object.keys(messages)
-            // eslint-disable-next-line no-undefined
-            .filter(messageName => messages[messageName].consume !== undefined)
+            .filter(messageName => typeof messages[messageName].consume !== 'undefined')
             .map(messageName => messages[messageName].consume()));
 
     }

--- a/idearium-lib/lib/mq/manager.js
+++ b/idearium-lib/lib/mq/manager.js
@@ -78,7 +78,7 @@ class Manager extends EventEmitter {
     /**
      * Publish a message
      * @param  {String} messageName Message name (should match the name of the message file)
-     * @return {[type]}             [description]
+     * @return {Promise}            A promise that will resolve when the message has published.
      */
     publish (messageName, ...args) {
 

--- a/idearium-lib/lib/mq/manager.js
+++ b/idearium-lib/lib/mq/manager.js
@@ -80,7 +80,7 @@ class Manager extends EventEmitter {
      * @param  {String} messageName Message name (should match the name of the message file)
      * @return {[type]}             [description]
      */
-    publish (messageName) {
+    publish (messageName, ...args) {
 
         /* eslint-disable padded-blocks */
         if (!this.messages[messageName]) {
@@ -95,9 +95,7 @@ class Manager extends EventEmitter {
         /* eslint-enable padded-blocks */
 
         // Remove first argument and publish.
-        // eslint-disable-next-line prefer-rest-params
-        const argsArray = [].slice.call(arguments).slice(1);
-        const result = this.messages[messageName].publish.apply(this, argsArray);
+        const result = this.messages[messageName].publish.apply(this, args);
 
         // If a promise is returned by the messages publish function, return it.
         /* eslint-disable padded-blocks */

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {

--- a/idearium-lib/test/common-mq-publisher.js
+++ b/idearium-lib/test/common-mq-publisher.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { expect } = require('chai');
+const dir = path.resolve(__dirname, '..', 'messages');
+const conf = require('./conf');
+
+describe('common/mq/publisher', function () {
+
+    let message;
+
+    // This is run after common-mq-client and will have therefore cached the config from the previous test.
+    // Set the mqUrl value as common/mq/client uses it.
+    before(function (done) {
+
+        // eslint-disable-next-line global-require
+        const config = require('../common/config');
+
+        config.set('mqUrl', conf.rabbitUrl);
+        config.set('logLocation', 'local');
+        config.set('logLevel', 'debug');
+        config.set('logToStdout', true);
+
+        // Add some fake messages to load.
+        fs.mkdir(dir, function (err) {
+
+            // If it already exists, that's fine, let's just create the file itself.
+            /* eslint-disable padded-blocks */
+            if (err) {
+                return done(err);
+            }
+            /* eslint-enable padded-blocks */
+
+            fs.writeFile(path.join(dir, 'test.js'), 'module.exports = { "consume": () => Promise.resolve(), "publish": () => Promise.resolve() };', function (writeErr) {
+
+                /* eslint-disable padded-blocks */
+                if (writeErr) {
+                    return done(writeErr);
+                }
+                /* eslint-enable padded-blocks */
+
+                // eslint-disable-next-line global-require
+                message = require('../messages/test.js');
+
+                return done();
+
+            });
+
+        });
+
+    });
+
+    it('will return a promise', function (done) {
+
+        // This runs after test/common-mq-client.
+        // That means some things have been cached.
+        // The following test has been setup to accomodate that.
+
+        // Create the publish function.
+        message.publish = function publishTest (data) {
+
+            expect(data).to.eql({ name: 'message-test' });
+
+            return Promise.resolve();
+
+        };
+
+        // eslint-disable-next-line global-require
+        const publish = require('../common/mq/publisher');
+
+        // Publish the message.
+        const result = publish('test', { name: 'message-test' });
+
+        expect(result).to.be.instanceof(Promise);
+
+        result
+            .then(() => done())
+            .catch(done);
+
+    });
+
+    after(function (done) {
+
+        fs.unlink(path.join(dir, 'test.js'), function () {
+
+            fs.rmdir(dir, done);
+
+        });
+
+    });
+
+});

--- a/idearium-lib/test/lib-mq-manager.js
+++ b/idearium-lib/test/lib-mq-manager.js
@@ -10,6 +10,16 @@ var expect = require('chai').expect,
 
 describe('class mq.Manager', function () {
 
+    before(function (done) {
+
+        fs.mkdir(dir, function () {
+
+            fs.writeFile(path.join(dir, 'test.js'), 'module.exports = { "consume": "" };', done);
+
+        });
+
+    });
+
     describe('will throw an Error', function () {
 
         it('if a path is not provided', function () {
@@ -26,17 +36,6 @@ describe('class mq.Manager', function () {
     });
 
     describe('with the messages directory', function () {
-
-        before(function (done) {
-
-            fs.mkdir(dir, function () {
-
-                fs.writeFile(path.join(dir, 'test.js'), 'module.exports = { "consume": "" };', done);
-
-            });
-
-        });
-
 
         it('will load messages and fire an event', function (done) {
 
@@ -80,12 +79,52 @@ describe('class mq.Manager', function () {
 
         });
 
-        after(function (done) {
-            fs.unlink(path.join(dir, 'test.js'), function () {
-                fs.rmdir(dir, done);
+
+    });
+
+    describe('publish', function () {
+
+        it('will return a promise', function (done) {
+
+            var mqManager = new mq.Manager(dir);
+
+            require(path.join(dir, 'test.js')).publish = function (data) {
+                return Promise.resolve();
+            };
+
+            mqManager.addListener('load', function () {
+
+                const publishResult = mqManager.publish('test', {'will-publish-a-message': true});
+                expect(publishResult instanceof Promise).to.be.true;
+                done();
+
             });
+
         });
 
+        it('will create and return a promise', function (done) {
+
+            var mqManager = new mq.Manager(dir);
+
+            require(path.join(dir, 'test.js')).publish = function (data) {
+            };
+
+            mqManager.addListener('load', function () {
+
+                const publishResult = mqManager.publish('test', {'will-publish-a-message': true});
+                expect(publishResult instanceof Promise).to.be.true;
+                done();
+
+            });
+
+        });
+
+    });
+
+    after(function (done) {
+        fs.unlink(path.join(dir, 'test.js'), function () {
+            fs.rmdir(dir, done);
+        });
     });
 
 });


### PR DESCRIPTION
This PR updates all instances of `publish` within the library, so that it they return a `Promise`. This has the advantage that you know when the message has actually been published - important in a recent use case in which this library was used in a Node.js cron script that would use `process.exit()`, rather than a web server which never exits.