### PR TITLE
Added some extra error logging to common/mq/publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Update `common/mq/publisher` to log error messages.
+
 ## 1.0.0-alpha.22
 
 - Update `mq.Manager().publish` to pass on a `Promise` if one was returned from the `message.publish` function, otherwise return `Promise.resolve()` by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## 1.0.0-alpha.23
 
 - Update `common/mq/publisher` to log error messages.
 

--- a/idearium-lib/common/mq/publisher.js
+++ b/idearium-lib/common/mq/publisher.js
@@ -12,11 +12,8 @@ const log = require('../log')('idearium-lib:common:mq/publisher');
 const publish = (type, data) => {
 
     return manager.publish(type, data)
-        .then(() => {
-
-            log.debug({ data, type }, `Publishing message of type: ${type}`);
-
-        });
+        .then(() => log.debug({ data, type }, `Published message of type: ${type}`))
+        .catch(err => log.error({ err }, `Could not publish message of type: ${type}`));
 
 };
 

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-alpha.23",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This is a quick little PR to improve some error logging, without this, unpublishable messages are easily unnoticed.

Now, when /common/mq/publisher can't publish a message, it logs it.