### PR TITLE
Query improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Make `options.filter` required for the query methods. Previously this would default to an empty filter if there was a typo in the options object which would cause unexpected results.
+
 ## 1.0.0-alpha.23
 
 - Update `common/mq/publisher` to log error messages.

--- a/idearium-lib/lib/query.js
+++ b/idearium-lib/lib/query.js
@@ -19,8 +19,11 @@
  */
 const getOptions = (options) => {
 
+    if (!options || !options.filter) {
+        throw new Error('A filter object must be provided');
+    }
+
     const defaults = {
-        filter: {},
         lean: true,
         limit: 10,
         projection: '_id',
@@ -28,7 +31,7 @@ const getOptions = (options) => {
 
     Object.assign(defaults, options);
 
-    // * must be passed to return all fields.
+    // * Must be passed to return all fields.
     if (options.projection === '*') {
         delete defaults.projection;
     }

--- a/idearium-lib/test/query.js
+++ b/idearium-lib/test/query.js
@@ -122,4 +122,10 @@ describe('query', function () {
 
     });
 
+    it('will error if no filter option is provided', function () {
+
+        expect(() => findOne(userModel)).to.throw(Error, 'A filter object must be provided');
+
+    });
+
 });


### PR DESCRIPTION
This should prevent accidental typos when using the query library eg`findOneUser({ filters: { test: 'test' } })`