### PR TITLE
Add api class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## 1.0.0-alpha.25
+
+- Added a new `Api` class to help generate consistent REST apis.
+
 ## 1.0.0-alpha.24
 
 - Improve error handling with `lib.util.parseCsv`.

--- a/idearium-lib/index.js
+++ b/idearium-lib/index.js
@@ -12,6 +12,7 @@ module.exports = {
     utils: require('./lib/utils'),
 
     // Export classes here.
+    Api: require('./lib/api'),
     Config: require('./lib/config'),
     Loader: require('./lib/loader'),
     Email: require('./lib/email'),

--- a/idearium-lib/lib/api.js
+++ b/idearium-lib/lib/api.js
@@ -1,0 +1,43 @@
+'use strict';
+
+class Api {
+
+    /**
+     * The api constructor.
+     * @param {String} baseUrl A base api url.
+     * @param {Object} defaults Default request module parameters that will be passed to all endpoints.
+     * @return {Void} Adds a baseUrl and defaults property to the class.
+     */
+    constructor (baseUrl, defaults) {
+
+        if (!baseUrl) {
+            throw new Error('A baseUrl must be provided');
+        }
+
+        this.baseUrl = baseUrl;
+        this.defaults = defaults;
+
+    }
+
+    /**
+     * Request an Api endpoint.
+     * @param {String} endpoint The api endpoint.
+     * @param {Object} options Override or add request module options.
+     * @return {Object} Returns request module options.
+     */
+    requestApi (endpoint, options = {}) {
+        return Object.assign({}, this.defaults, options, { uri: `${this.baseUrl}${endpoint}` });
+    }
+
+    /**
+     * Add an Api endpoint.
+     * @param {String} name The name of the endpoint.
+     * @param {Object} endpoints Object containing endpoint functions to generate the request module options.
+     */
+    addEndpoint (name, endpoints) {
+        this[name] = endpoints;
+    }
+
+}
+
+module.exports = Api;

--- a/idearium-lib/lib/api.js
+++ b/idearium-lib/lib/api.js
@@ -5,10 +5,10 @@ class Api {
     /**
      * The api constructor.
      * @param {String} baseUrl A base api url.
-     * @param {Object} defaults Default request module parameters that will be passed to all endpoints.
+     * @param {Object} [defaults={}] Default request module parameters that will be passed to all endpoints.
      * @return {Void} Adds a baseUrl and defaults property to the class.
      */
-    constructor (baseUrl, defaults) {
+    constructor (baseUrl, defaults = {}) {
 
         if (!baseUrl) {
             throw new Error('A baseUrl must be provided');
@@ -22,7 +22,7 @@ class Api {
     /**
      * Request an Api endpoint.
      * @param {String} endpoint The api endpoint.
-     * @param {Object} options Override or add request module options.
+     * @param {Object} [options={}] Override or add request module options.
      * @return {Object} Returns request module options.
      */
     requestApi (endpoint, options = {}) {
@@ -33,6 +33,7 @@ class Api {
      * Add an Api endpoint.
      * @param {String} name The name of the endpoint.
      * @param {Object} endpoints Object containing endpoint functions to generate the request module options.
+     * @return {Void} Adds the endpoint to the class.
      */
     addEndpoint (name, endpoints) {
         this[name] = endpoints;

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {

--- a/idearium-lib/test/lib-api.js
+++ b/idearium-lib/test/lib-api.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { expect } = require('chai');
+const { Api } = require('../');
+
+describe('class Api', function () {
+
+    it('should fail if the baseUrl parameter is not provided', function () {
+
+        expect(function () {
+
+            return new Api();
+
+        }).to.throw(Error);
+
+    });
+
+    it('should use the defaults', function () {
+
+        const api = new Api('https://test.com', { test: 'test' });
+
+        expect(api.defaults).to.eql({ test: 'test' });
+
+    });
+
+    it('should provide a requestApi function', function () {
+
+        const api = new Api('https://test.com');
+
+        expect(api.requestApi('/test')).to.eql({ uri: 'https://test.com/test' });
+
+    });
+
+    it('should add an endpoint', function () {
+
+        const api = new Api('https://test.com');
+
+        api.addEndpoint('tests', { getTest: () => api.requestApi('/test') });
+
+        expect(api.tests).to.have.all.keys('getTest');
+        expect(api.tests.getTest()).to.eql({ uri: 'https://test.com/test' });
+
+    });
+
+});


### PR DESCRIPTION
This PR adds a simple api class to allow us to create consistent apis in our projects.

## Example

```javascript
'use strict';

const config = require('./config');
const { Api } = require('@idearium/idearium-lib');

/* eslint-disable object-curly-newline */
const api = new Api(`${config.get('mailgunBaseUrl')}`, {
    headers: {
        Authorization: `Basic ${(Buffer.from(config.get('mailgunApiKey'))).toString('base64')}`,
    },
});

api.addEndpoint('messages', {
    send: (form, options) => api.requestApi(`/${config.get('mailgunDomain')}/messages`, Object.assign({ form, method: 'POST' }, options)),
});
/* eslint-enable object-curly-newline */

module.exports = api;
```