### PR TITLE
Opbeat improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Disabled OPBEAT when in test mode.
+
 ## 1.0.0-alpha.25
 
 - Added a new `Api` class to help generate consistent REST apis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## 1.0.0-alpha.26
 
 - Disabled OPBEAT when in test mode.
 

--- a/idearium-lib/common/opbeat.js
+++ b/idearium-lib/common/opbeat.js
@@ -2,13 +2,14 @@
 
 const config = require('./config');
 const opbeat = require('opbeat');
-const { isDevelopment } = require('../lib/util');
+const { isDevelopment, isTest } = require('../lib/util');
 
 // Determine if Opbeat should be enabled.
 // eslint-disable-next-line no-process-env
 const includeOpbeat = Object.keys(process.env)
     .includes('OPBEAT_OVERRIDE');
-const opbeatEnabled = includeOpbeat || !isDevelopment(config.get('env'));
+const env = config.get('env');
+const opbeatEnabled = includeOpbeat || (!isDevelopment(env) && !isTest(env));
 
 // Setup Opbeat to query the data.
 opbeat.start({

--- a/idearium-lib/lib/util/is.js
+++ b/idearium-lib/lib/util/is.js
@@ -50,6 +50,13 @@ const isProduction = str => str.toLowerCase() === 'production';
  */
 const isStaging = str => str.toLowerCase() === 'staging';
 
+/**
+ * Determine if the environment is test.
+ * @param {String} str String to compare.
+ * @return {Boolean} True if the environment is test.
+ */
+const isTest = str => str.toLowerCase() === 'test';
+
 module.exports = {
     isArray,
     isBeta,
@@ -58,4 +65,5 @@ module.exports = {
     isObject,
     isProduction,
     isStaging,
+    isTest,
 };

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.25",
+  "version": "1.0.0-alpha.26",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {

--- a/idearium-lib/test/util-is.js
+++ b/idearium-lib/test/util-is.js
@@ -9,6 +9,7 @@ const {
     isObject,
     isProduction,
     isStaging,
+    isTest,
 } = require('../lib/util');
 
 describe('util-is', function () {
@@ -31,6 +32,10 @@ describe('util-is', function () {
 
     it('is production environment', function () {
         expect(isProduction('PrOdUcTiOn')).to.equal(true);
+    });
+
+    it('is test environment', function () {
+        expect(isTest('TesT')).to.equal(true);
     });
 
     it('should be equal', function () {


### PR DESCRIPTION
This is just a quick PR to stop OPBEAT from reporting errors in test mode. This allows us to test errors, without them appearing in OPBEAT (which would be silly).