### PR TITLE
Prettystream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is a history of the changes made to idearium-lib.
 
 ## Unreleased
 
-- Added `bunyan-prettystream` for the local environment.
+- Added `bunyan-prettystream` for the local environment. This can be manually enabled by creating a `Logger` with `pretty` set to true.
 
 ## 1.0.0-alpha.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Added `bunyan-prettystream` for the local environment.
+
 ## 1.0.0-alpha.26
 
 - Disabled OPBEAT when in test mode.

--- a/idearium-lib/common/log.js
+++ b/idearium-lib/common/log.js
@@ -26,6 +26,7 @@ const log = (context, name = 'application') => {
         level: logLevel,
         local: logLocation.toLowerCase() === 'local',
         name,
+        pretty: logLocation.toLowerCase() === 'local',
         remote: logLocation.toLowerCase() === 'remote',
         serializers: {
             err: bunyan.stdSerializers.err,

--- a/idearium-lib/lib/logs/logger.js
+++ b/idearium-lib/lib/logs/logger.js
@@ -58,7 +58,7 @@ function getStreams (_streams) {
 
         // Are we going to log to stdErr?
         if (this.stdErr) {
-            this._streams.push(this.stdErrStream(this.local));
+            this._streams.push(this.stdErrStream(this.pretty));
         }
 
         // Are we going to log remotely?
@@ -99,6 +99,7 @@ class Logger {
         this.level = opts.level || 'warn';
         this.remote = typeof opts.remote === 'undefined' ? false : opts.remote;
         this.token = opts.token || undefined;
+        this.pretty = opts.pretty || false;
         this.local = typeof opts.local === 'undefined' ? true : opts.local;
         this.stdErr = typeof opts.stdErr === 'undefined' ? false : opts.stdErr;
         this.dir = opts.dir || path.join(path.resolve(process.cwd()), 'logs');
@@ -158,11 +159,11 @@ class Logger {
 
     /**
      * Retrieve a stderr stream.
-     * @param {Boolean} [isLocal=false] Set to true for local debugging.
+     * @param {Boolean} [pretty=false] Set to true for pretty bunyan streams.
      * @return {object} A stderr stream for Bunyan.
      */
-    stdErrStream (isLocal = false) {
-        return new pkgStreams.StdErr(this.name, this.level, this.context).forBunyan(isLocal);
+    stdErrStream (pretty = false) {
+        return new pkgStreams.StdErr(this.name, this.level, this.context).forBunyan(pretty);
     }
 
     /**

--- a/idearium-lib/lib/logs/logger.js
+++ b/idearium-lib/lib/logs/logger.js
@@ -58,7 +58,7 @@ function getStreams (_streams) {
 
         // Are we going to log to stdErr?
         if (this.stdErr) {
-            this._streams.push(this.stdErrStream());
+            this._streams.push(this.stdErrStream(this.local));
         }
 
         // Are we going to log remotely?
@@ -158,10 +158,11 @@ class Logger {
 
     /**
      * Retrieve a stderr stream.
+     * @param {Boolean} [isLocal=false] Set to true for local debugging.
      * @return {object} A stderr stream for Bunyan.
      */
-    stdErrStream () {
-        return new pkgStreams.StdErr(this.name, this.level, this.context).forBunyan();
+    stdErrStream (isLocal = false) {
+        return new pkgStreams.StdErr(this.name, this.level, this.context).forBunyan(isLocal);
     }
 
     /**

--- a/idearium-lib/lib/logs/streams/std-err.js
+++ b/idearium-lib/lib/logs/streams/std-err.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const PrettyStream = require('bunyan-prettystream');
+
+const prettyStdOut = new PrettyStream();
+
+// Prettify the bunyan json stream.
+prettyStdOut.pipe(process.stdout);
+
 /**
  * A class to be used as a Bunyan stream. It will take the information and log via `debug`.
  */
@@ -31,14 +38,15 @@ class StdErr {
 
     /**
      * Produce an object suitable to describe a Bunyan stream.
+     * @param {Boolean} [isLocal=false] Set to true for local debugging.
      * @return {object} An object that Bunyan can pass a stream.
      */
-    forBunyan () {
+    forBunyan (isLocal = false) {
 
         return {
             name: this.name,
             level: this.level,
-            stream: this
+            stream: isLocal ? prettyStdOut : this,
         }
 
     }

--- a/idearium-lib/lib/logs/streams/std-err.js
+++ b/idearium-lib/lib/logs/streams/std-err.js
@@ -38,15 +38,15 @@ class StdErr {
 
     /**
      * Produce an object suitable to describe a Bunyan stream.
-     * @param {Boolean} [isLocal=false] Set to true for local debugging.
+     * @param {Boolean} [pretty=false] Set to true for pretty bunyan streams.
      * @return {object} An object that Bunyan can pass a stream.
      */
-    forBunyan (isLocal = false) {
+    forBunyan (pretty = false) {
 
         return {
             name: this.name,
             level: this.level,
-            stream: isLocal ? prettyStdOut : this,
+            stream: pretty ? prettyStdOut : this,
         }
 
     }

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -22,6 +22,7 @@
     "async": "2.4.1",
     "bcryptjs": "2.4.0",
     "bunyan": "1.8.1",
+    "bunyan-prettystream": "0.1.3",
     "connect-redis": "3.3.0",
     "csv-parse": "1.2.0",
     "debug": "2.2.0",


### PR DESCRIPTION
Quick PR to add `bunyan-prettystream` to the local stderr. This should help scan over the logs when in development.

## Testing

- [ ] Map this in to a project and view the logs.

## Notes

- It should only be available over local because it isn't very performant (I think since it is only inteded for the development environment) and logentries already does this for us.