### PR TITLE
Elastic apm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## v1.0.0-alpha.30 (14 May 2018)
+
+- Fixed errors not being logged to console.
+- Fixed unhandled promises not stopping the node process.
+
 ## v1.0.0-alpha.29 (4 May 2018)
 
 - Fix apm.setUserContext is not a function error.

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -2,8 +2,10 @@
 
 const apm = require('elastic-apm-node');
 const config = require('./config');
+const exception = require('./exception');
 
 const ignoreUrls = (config.get('elasticApmIgnoreUrls') || '').split(',');
+const logLevel = config.get('elasticApmLogLevel') || 'debug';
 
 // Set some defaults.
 if (!ignoreUrls.length) {
@@ -13,10 +15,13 @@ if (!ignoreUrls.length) {
 
 }
 
-apm.start({ ignoreUrls });
+apm.start({
+    ignoreUrls,
+    logLevel,
+});
 
-process.on('unhandledRejection', err => apm.captureError(err));
+process.on('unhandledRejection', err => apm.captureError(err, exception));
 
-apm.handleUncaughtExceptions(require('./exception'));
+apm.handleUncaughtExceptions(exception);
 
 module.exports = apm;


### PR DESCRIPTION
Quick fix to make sure everything logged to apm is being logged to console.
Also fixes an issue where unhandled promises were not exiting the node process.