### PR TITLE
Removed the use of Loader when creating structure in lib exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## v1.0.0-alpha.31 (16 May 2018)
+
+- Removed the use of Loader when generated `module.exports` objects in `lib`.
+
 ## v1.0.0-alpha.30 (14 May 2018)
 
 - Fixed errors not being logged to console.

--- a/idearium-lib/lib/email-services/index.js
+++ b/idearium-lib/lib/email-services/index.js
@@ -1,11 +1,7 @@
 'use strict';
 
-var Loader = require('../loader'),
-    loader;
+const Mandrill = require('./mandrill');
 
-// Create an instance of Loader, and configure it with ClassCase.
-loader = new Loader();
-loader.classCase = true;
-loader.sync = true;
-
-module.exports = loader.load(__dirname);
+module.exports = {
+    Mandrill,
+};

--- a/idearium-lib/lib/logs/index.js
+++ b/idearium-lib/lib/logs/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var Loader = require('../loader'),
-    loader;
+const Logger = require('./logger');
+const streams = require('./streams');
 
-// Create an instance of Loader, and configure it with ClassCase.
-loader = new Loader();
-loader.classCase = true;
-loader.sync = true;
-
-module.exports = loader.load(__dirname);
+module.exports = {
+    Logger,
+    streams,
+};

--- a/idearium-lib/lib/logs/streams/index.js
+++ b/idearium-lib/lib/logs/streams/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var Loader = require('../../loader'),
-    loader;
+const LogEntries = require('./log-entries');
+const StdErr = require('./std-err');
 
-// Create an instance of Loader, and configure it with ClassCase.
-loader = new Loader();
-loader.classCase = true;
-loader.sync = true;
-
-module.exports = loader.load(__dirname);
+module.exports = {
+    LogEntries,
+    StdErr,
+};

--- a/idearium-lib/lib/mq/index.js
+++ b/idearium-lib/lib/mq/index.js
@@ -1,6 +1,14 @@
 
-module.exports.Client = require('./client');
-module.exports.Manager = require('./manager');
-module.exports.Connection = require('./connection');
-module.exports.RpcServer = require('./rpc-server');
-module.exports.RpcClient = require('./rpc-client');
+const Client = require('./client');
+const Connection = require('./connection');
+const Manager = require('./manager');
+const RpcClient = require('./rpc-client');
+const RpcServer = require('./rpc-server');
+
+module.exports = {
+    Client,
+    Connection,
+    Manager,
+    RpcClient,
+    RpcServer,
+};

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-alpha.31",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Using Loader to load some files for use in an `module.exports` object is causing a little instability and issues in some rare edge cases. It's also not providing a lot of benefit, and you'll see that the code is much simpler with it replaced.

I pushed and tested this and it's working well. All the tests have passed too.

## Testing

- [ ] Update a `package.json` to use `"@idearium/idearium-lib": "1.0.0-alpha.31"`.
- [ ] Build your project.
- [ ] Load it and make sure everything works.