### PR TITLE
Don't stop the process for unhandled rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to idearium-lib.
 
+## Unreleased
+
+- Updated apm to only log `unhandledRejection` and rethrow the error without forcing a restart. By default the error will still get captured by `apm.handleUncaughtExceptions` and restart the process.
+
 ## v1.0.0-alpha.33 (18 May 2018)
 
 - Updated apm to use environment variables only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This file is a history of the changes made to idearium-lib.
 
 ## Unreleased
 
-- Updated apm to only log `unhandledRejection` and rethrow the error without forcing a restart. By default the error will still get captured by `apm.handleUncaughtExceptions` and restart the process.
+- Updated apm to allow custom `unhandledRejection` and `apm.handleUncaughtExceptions` exception handlers. Just set `apm.exception = () => { ... }` in the app.
+- Updated the default exception handler to call `log.error` instead of just console.log.
 
 ## v1.0.0-alpha.33 (18 May 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to idearium-lib.
 
-## Unreleased
+## v1.0.0-alpha.34 (25 May 2018)
 
 - Updated apm to allow custom `unhandledRejection` and `apm.handleUncaughtExceptions` exception handlers. Just set `apm.exception = () => { ... }` in the app.
 - Updated the default exception handler to call `log.error` instead of just console.log.

--- a/idearium-lib/.github/ISSUE_TEMPLATE.md
+++ b/idearium-lib/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Expected behaviour
+
+
+
+## Actual behaviour
+
+
+
+## Steps to reproduce the behaviour
+
+1.
+
+## Environment
+
+- OS: ?
+- Browser (and version): ?

--- a/idearium-lib/.github/PULL_REQUEST_TEMPLATE.md
+++ b/idearium-lib/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+A brief summary of your PR.
+
+## Setup
+
+- [ ] A list of steps to get started with testing.
+
+## Related PRs
+
+- #
+
+## Issues
+
+- Fixes #
+
+## Testing
+
+- [ ] All the steps required to complete testing the PR.
+
+## Notes
+
+- Any additional notes you think will be useful.

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -24,13 +24,8 @@ apm.start({
     serverUrl,
 });
 
-process.on('unhandledRejection', err => apm.captureError(err, () => {
-
-    log.error({ err }, err.message);
-
-    throw err;
-
-}));
+// Just capture and log the error.
+process.on('unhandledRejection', err => apm.captureError(err, () => log.error({ err }, err.message)));
 
 apm.handleUncaughtExceptions(exception);
 

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -2,6 +2,7 @@
 
 const apm = require('elastic-apm-node');
 const exception = require('./exception');
+const log = require('./log')('idearium-lib:common/apm');
 
 /* eslint-disable no-process-env */
 const ignoreUrls = (process.env.ELASTIC_APM_IGNORE_URLS || '').split(',');
@@ -23,7 +24,13 @@ apm.start({
     serverUrl,
 });
 
-process.on('unhandledRejection', err => apm.captureError(err, () => exception(err)));
+process.on('unhandledRejection', err => apm.captureError(err, () => {
+
+    log.error({ err }, err.message);
+
+    throw err;
+
+}));
 
 apm.handleUncaughtExceptions(exception);
 

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -24,7 +24,7 @@ apm.start({
     serverUrl,
 });
 
-process.on('unhandledRejection', err => apm.captureError(err, apm.exception(err)));
+process.on('unhandledRejection', err => apm.captureError(err, () => apm.exception(err)));
 
 apm.handleUncaughtExceptions(apm.exception);
 

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const apm = require('elastic-apm-node');
-const exception = require('./exception');
-const log = require('./log')('idearium-lib:common/apm');
+
+apm.exception = require('./exception');
 
 /* eslint-disable no-process-env */
 const ignoreUrls = (process.env.ELASTIC_APM_IGNORE_URLS || '').split(',');
@@ -24,16 +24,8 @@ apm.start({
     serverUrl,
 });
 
-// Capture and rethrow the error so apps can handle it themselves.
-// By default the apm handler below will capture it.
-process.on('unhandledRejection', err => apm.captureError(err, () => {
+process.on('unhandledRejection', err => apm.captureError(err, apm.exception(err)));
 
-    log.error({ err }, err.message);
-
-    throw err;
-
-}));
-
-apm.handleUncaughtExceptions(exception);
+apm.handleUncaughtExceptions(apm.exception);
 
 module.exports = apm;

--- a/idearium-lib/common/apm.js
+++ b/idearium-lib/common/apm.js
@@ -24,8 +24,15 @@ apm.start({
     serverUrl,
 });
 
-// Just capture and log the error.
-process.on('unhandledRejection', err => apm.captureError(err, () => log.error({ err }, err.message)));
+// Capture and rethrow the error so apps can handle it themselves.
+// By default the apm handler below will capture it.
+process.on('unhandledRejection', err => apm.captureError(err, () => {
+
+    log.error({ err }, err.message);
+
+    throw err;
+
+}));
 
 apm.handleUncaughtExceptions(exception);
 

--- a/idearium-lib/common/exception.js
+++ b/idearium-lib/common/exception.js
@@ -1,17 +1,13 @@
 'use strict';
 
-const debug = require('debug')('idearium-lib:common:exception');
-const exitErrCode = 1;
+const log = require('./log')('idearium-lib:common/exception');
 
-module.exports = function (err) {
+module.exports = (err) => {
 
-    debug('Exception logged. Quitting Node.js process.');
-
-    // Log the error to console.
-    // eslint-disable-next-line no-console
-    console.error(err);
+    log.error({ err }, err.message);
 
     // Quit the process entirely.
-    process.exit(exitErrCode);
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
 
 };

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/idearium-lib",
-  "version": "1.0.0-alpha.33",
+  "version": "1.0.0-alpha.34",
   "description": "A Node.js shared library for Idearium applications.",
   "main": "index.js",
   "directories": {

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -33,6 +33,7 @@
     "moment": "2.21.0",
     "mongoose": "4.10.4",
     "nconf": "0.8.4",
+    "shelljs": "0.8.2",
     "stream-to-promise": "2.2.0",
     "stream-transform": "0.1.2",
     "uuid": "3.0.1",

--- a/idearium-lib/package.json
+++ b/idearium-lib/package.json
@@ -25,7 +25,7 @@
     "connect-redis": "3.3.0",
     "csv-parse": "1.2.0",
     "debug": "2.2.0",
-    "elastic-apm-node": "1.4.0",
+    "elastic-apm-node": "1.5.4",
     "express-session": "1.15.3",
     "kue": "0.11.6",
     "le_node": "1.3.1",

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -11,6 +11,10 @@ const path = require('path');
 
 describe('common/exception', function () {
 
+    // Sometimes there is a bit of lag when writing to the socket and file system.
+    // Allow two retries on these tests.
+    this.retries(2);
+
     const pe = process.exit;
     let exception;
 

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -5,6 +5,7 @@ const {
     cleanUp,
     logPath,
     makeConfigs,
+    makeLogs,
 } = require('./util');
 const fs = require('fs');
 const path = require('path');
@@ -14,7 +15,10 @@ describe('common/exception', function () {
     const pe = process.exit;
     let exception;
 
-    before(() => makeConfigs()
+    before(() => Promise.all([
+        makeConfigs(),
+        makeLogs(),
+    ])
         .then(() => {
 
             process.exit = () => { };

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -17,18 +17,13 @@ describe('common/exception', function () {
     before(() => makeConfigs()
         .then(() => {
 
+            const config = require('../common/config');
+
+            config.set('logLocation', 'local');
+            config.set('logLevel', 'debug');
+            config.set('logToStdout', true);
             exception = require('../common/exception');
-
-            return Promise.resolve();
-
-        }));
-
-    beforeEach(() => makeConfigs()
-        .then(() => {
-
             process.exit = () => { };
-
-            return Promise.resolve();
 
         }));
 
@@ -57,7 +52,7 @@ describe('common/exception', function () {
 
     });
 
-    afterEach(() => cleanUp()
+    after(() => cleanUp()
         .then(() => {
 
             process.exit = pe;

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -11,13 +11,13 @@ const path = require('path');
 
 describe('common/exception', function () {
 
-    this.timeout(3000);
-
     const pe = process.exit;
     let exception;
 
     before(() => makeConfigs()
         .then(() => {
+
+            process.exit = () => { };
 
             const config = require('../common/config');
 
@@ -25,7 +25,6 @@ describe('common/exception', function () {
             config.set('logLevel', 'debug');
             config.set('logToStdout', true);
             exception = require('../common/exception');
-            process.exit = () => { };
 
         }));
 
@@ -37,25 +36,20 @@ describe('common/exception', function () {
 
         exception(new Error('An exception'));
 
-        // Allow time for the file to be created.
-        setTimeout(() => {
+        // Verify the log exists.
+        fs.readFile(path.join(logPath, 'application.log'), 'utf8', function (err, content) {
 
-            // Verify the log exists.
-            fs.readFile(path.join(logPath, 'application.log'), 'utf8', function (err, content) {
+            // Handle any errors
+            if (err) {
+                return done(err);
+            }
 
-                // Handle any errors
-                if (err) {
-                    return done(err);
-                }
+            // Check out results.
+            expect(content).to.match(/An exception/);
 
-                // Check out results.
-                expect(content).to.match(/An exception/);
+            return done();
 
-                return done();
-
-            });
-
-        }, 1000);
+        });
 
     });
 

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -11,9 +11,7 @@ const path = require('path');
 
 describe('common/exception', function () {
 
-    // Sometimes there is a bit of lag when writing to the socket and file system.
-    // Allow two retries on these tests.
-    this.retries(2);
+    this.timeout(3000);
 
     const pe = process.exit;
     let exception;
@@ -39,20 +37,25 @@ describe('common/exception', function () {
 
         exception(new Error('An exception'));
 
-        // Verify the log exists.
-        fs.readFile(path.join(logPath, 'application.log'), 'utf8', function (err, content) {
+        // Allow time for the file to be created.
+        setTimeout(() => {
 
-            // Handle any errors
-            if (err) {
-                return done(err);
-            }
+            // Verify the log exists.
+            fs.readFile(path.join(logPath, 'application.log'), 'utf8', function (err, content) {
 
-            // Check out results.
-            expect(content).to.match(/An exception/);
+                // Handle any errors
+                if (err) {
+                    return done(err);
+                }
 
-            return done();
+                // Check out results.
+                expect(content).to.match(/An exception/);
 
-        });
+                return done();
+
+            });
+
+        }, 1000);
 
     });
 

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -14,26 +14,19 @@ describe('common/exception', function () {
     const pe = process.exit;
     let exception;
 
-    before(function (done) {
+    before(() => makeConfigs()
+        .then(() => {
 
-        makeConfigs()
-            .then(() => {
+            process.exit = () => { };
 
-                process.exit = () => { };
+            const config = require('../common/config');
 
-                const config = require('../common/config');
+            config.set('logLocation', 'local');
+            config.set('logLevel', 'debug');
+            config.set('logToStdout', true);
+            exception = require('../common/exception');
 
-                config.set('logLocation', 'local');
-                config.set('logLevel', 'debug');
-                config.set('logToStdout', true);
-                exception = require('../common/exception');
-
-                return done();
-
-            })
-            .catch(done);
-
-    });
+        }));
 
     it('is a function', function () {
         expect(exception).to.be.a('function');

--- a/idearium-lib/test/common-exception.js
+++ b/idearium-lib/test/common-exception.js
@@ -14,19 +14,26 @@ describe('common/exception', function () {
     const pe = process.exit;
     let exception;
 
-    before(() => makeConfigs()
-        .then(() => {
+    before(function (done) {
 
-            process.exit = () => { };
+        makeConfigs()
+            .then(() => {
 
-            const config = require('../common/config');
+                process.exit = () => { };
 
-            config.set('logLocation', 'local');
-            config.set('logLevel', 'debug');
-            config.set('logToStdout', true);
-            exception = require('../common/exception');
+                const config = require('../common/config');
 
-        }));
+                config.set('logLocation', 'local');
+                config.set('logLevel', 'debug');
+                config.set('logToStdout', true);
+                exception = require('../common/exception');
+
+                return done();
+
+            })
+            .catch(done);
+
+    });
 
     it('is a function', function () {
         expect(exception).to.be.a('function');

--- a/idearium-lib/test/scripts/test.sh
+++ b/idearium-lib/test/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-DEBUG=lib:logger:*,idearium-lib:common:exception BLUEBIRD_WARNINGS=0 "/app/node_modules/.bin/_mocha"
+DEBUG=lib:logger:*,idearium-lib:common/exception BLUEBIRD_WARNINGS=0 "/app/node_modules/.bin/_mocha"

--- a/idearium-lib/test/util/index.js
+++ b/idearium-lib/test/util/index.js
@@ -10,6 +10,8 @@ const path = require('path');
 
 const configPath = path.join(process.cwd(), 'config');
 const logPath = path.join(process.cwd(), 'logs');
+const mongoCertsPath = path.join(process.cwd(), 'mongo-certs');
+const mqCertsPath = path.join(process.cwd(), 'mq-certs');
 
 /**
  * Make a path if it doesn't already exist.
@@ -72,6 +74,8 @@ const makeFile = (dir, options) => new Promise((resolve) => {
 
 const removePath = dir => Promise.resolve(rm('-rf', dir));
 
+module.exports.makePath = makePath;
+
 module.exports.makeConfigs = (content, options) => makePath(configPath, options.path)
     .then(() => makeFile(`${configPath}/config.js`, options.file));
 
@@ -80,4 +84,8 @@ module.exports.makeLogs = options => makePath(logPath, options.path);
 module.exports.cleanUp = Promise.all([
     removePath(configPath),
     removePath(logPath),
+    removePath(mongoCertsPath),
+    removePath(mqCertsPath),
 ]);
+
+module.exports.logPath = logPath;

--- a/idearium-lib/test/util/index.js
+++ b/idearium-lib/test/util/index.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const {
+    mkdir,
+    rm,
+    touch,
+} = require('shelljs');
+const rimraf = require('rimraf');
+const path = require('path');
+
+const configPath = path.join(process.cwd(), 'config');
+const logPath = path.join(process.cwd(), 'logs');
+
+/**
+ * Make a path if it doesn't already exist.
+ * @param {String} dir The path.
+ * @param {Object} options The options.
+ * @param {Boolean} [options.clean=true] Optionally wipe the directory.
+ * @return {Promise} Makes the path.
+ */
+const makePath = (dir, options) => new Promise((resolve, reject) => {
+
+    const settings = Object.assign({}, { clean: true }, options);
+
+    // Create the directory if it doesn't already exist.
+    mkdir('-p', dir);
+
+    if (!settings.clean) {
+        return resolve();
+    }
+
+    // Wipe all the files in the directory.
+    rimraf(dir, () => (err) => {
+
+        if (err) {
+            return reject(err);
+        }
+
+        return resolve();
+
+    });
+
+});
+
+/**
+ * Make a file.
+ * @param {String} dir The file path.
+ * @param {Object} options The options.
+ * @param {Boolean} [options.clean=true] Optionally wipe the file.
+ * @param {Boolean} [options.content='module.exports = {}'] Optionally provide file contents.
+ * @return {Promise} Makes the file.
+ */
+const makeFile = (dir, options) => new Promise((resolve) => {
+
+    const settings = Object.assign({}, {
+        clean: true,
+        content: 'module.exports = {}',
+    }, options);
+
+    if (settings.clean) {
+        rm(dir);
+    }
+
+    touch(dir);
+    // Add the content to the file.
+    settings.content.to(dir);
+
+    return resolve();
+
+});
+
+
+const removePath = dir => Promise.resolve(rm('-rf', dir));
+
+module.exports.makeConfigs = (content, options) => makePath(configPath, options.path)
+    .then(() => makeFile(`${configPath}/config.js`, options.file));
+
+module.exports.makeLogs = options => makePath(logPath, options.path);
+
+module.exports.cleanUp = Promise.all([
+    removePath(configPath),
+    removePath(logPath),
+]);

--- a/idearium-lib/test/util/index.js
+++ b/idearium-lib/test/util/index.js
@@ -20,6 +20,8 @@ const removePath = dir => Promise.resolve(rm('-rf', dir));
  */
 const makePath = (dir) => {
 
+    console.log(`Making path ${dir}`);
+
     // Create the directory if it doesn't already exist.
     mkdir('-p', dir);
 

--- a/idearium-lib/test/util/index.js
+++ b/idearium-lib/test/util/index.js
@@ -20,8 +20,6 @@ const removePath = dir => Promise.resolve(rm('-rf', dir));
  */
 const makePath = (dir) => {
 
-    console.log(`Making path ${dir}`);
-
     // Create the directory if it doesn't already exist.
     mkdir('-p', dir);
 
@@ -66,7 +64,7 @@ module.exports = {
     makeConfigs: (content, options) => makePath(configPath)
         .then(() => makeFile(`${configPath}/config.js`, Object.assign({}, options, { content }))),
     makeFile,
-    makeLogs: options => makePath(logPath, options.path),
+    makeLogs: () => makePath(logPath),
     makePath,
     removePath,
 };

--- a/idearium-lib/yarn.lock
+++ b/idearium-lib/yarn.lock
@@ -724,7 +724,7 @@ dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
 
-debug@*, debug@^3.0.0, debug@^3.1.0:
+debug@*, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -873,16 +873,15 @@ elastic-apm-http-client@^5.2.0:
   dependencies:
     fast-safe-stringify "^1.2.0"
 
-elastic-apm-node@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-1.4.0.tgz#e96c093977e74d1f0c4651774124aafe9b28b512"
+elastic-apm-node@1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-1.5.4.tgz#d1ef2af1cde7e9c171c77bbde2552e78f172dfd8"
   dependencies:
     after-all-results "^2.0.0"
     async-value-promise "^1.1.0"
     console-log-level "^1.4.0"
     cookie "^0.3.1"
     core-util-is "^1.0.2"
-    debug "^3.0.0"
     elastic-apm-http-client "^5.2.0"
     end-of-stream "^1.1.0"
     fast-safe-stringify "^2.0.3"

--- a/idearium-lib/yarn.lock
+++ b/idearium-lib/yarn.lock
@@ -1475,7 +1475,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -3488,6 +3488,14 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shelljs@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR stops unhandled rejection errors from stopping the process.

## Setup

- [x] Map this into a project that currently throws `exception: _id index cannot be non-unique` errors.

## Testing

- [x] Make sure the project starts and an error is logged, but the process continues.

## Notes

- Here is an example of what you should now see:
```shell
logging error 3d5090af-349d-49bd-bcea-9fcaadba711f with Elastic APM
Thu, 24 May 2018 07:38:15 GMT idearium-lib:common/apm {"name":"application","hostname":"6df7ddc433a5","pid":323,"context":"idearium-lib:common/apm","level":50,"err":{"message":"exception: _id index cannot be non-unique","name":"MongoError","stack":"MongoError: exception: _id index cannot be non-unique\n    at Function.MongoError.create (/app/node_modules/mongoose/node_modules/mongodb-core/lib/error.js:31:11)\n    at /app/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:497:72\n    at authenticateStragglers (/app/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:443:16)\n    at Connection.messageHandler (/app/node_modules/mongoose/node_modules/mongodb-core/lib/connection/pool.js:477:5)\n    at Socket.<anonymous> (/app/node_modules/mongoose/node_modules/mongodb-core/lib/connection/connection.js:333:22)\n    at emitOne (events.js:96:13)\n    at Socket.emit (events.js:188:7)\n    at readableAddChunk (_stream_readable.js:176:18)\n    at Socket.Readable.push (_stream_readable.js:134:10)\n    at TCP.onread [as _obOriginalOnread] (net.js:547:20)\n    at TCP.elasticAPMCallbackWrapper [as onread] (/app/node_modules/@idearium/idearium-lib/node_modules/elastic-apm-node/lib/instrumentation/index.js:149:27)","code":67},"msg":"exception: _id index cannot be non-unique","time":"2018-05-24T07:38:15.526Z","v":0}
```
