### PR TITLE
Mq retry

### DIFF
--- a/idearium-lib/common/mq/client.js
+++ b/idearium-lib/common/mq/client.js
@@ -107,7 +107,7 @@ class Client extends mq.Client {
 
         if (this.reconnectCount >= retryLimit) {
 
-            log.fatal('Retry limit reached, could not connect to RabbitMQ');
+            log.fatal(`Retry limit of ${retryLimit} reached, could not connect to RabbitMQ`);
 
             // eslint-disable-next-line no-process-exit
             return process.exit(1);

--- a/idearium-lib/common/mq/client.js
+++ b/idearium-lib/common/mq/client.js
@@ -65,7 +65,7 @@ class Client extends mq.Client {
         // Update the state
         this.state = 'connecting';
 
-        // Delay for 1 second to precent TLS errors on startup.
+        // Delay for 1 second to prevent TLS errors on startup.
         setTimeout(() => {
 
             amqp.connect(this.mqUrl, this.options)

--- a/idearium-lib/common/mq/rpc-client.js
+++ b/idearium-lib/common/mq/rpc-client.js
@@ -62,7 +62,7 @@ class RpcClient extends mq.RpcClient {
         // Update the state
         this.state = 'connecting';
 
-        // Delay for 1 second to precent TLS errors on startup.
+        // Delay for 1 second to prevent TLS errors on startup.
         setTimeout(() => {
 
             amqp.connect(this.mqUrl, this.options)

--- a/idearium-lib/common/mq/rpc-client.js
+++ b/idearium-lib/common/mq/rpc-client.js
@@ -1,15 +1,19 @@
 'use strict';
 
-var mq = require('../../lib/mq'),
-    config = require('../config'),
-    certs = require('./certs');
+const amqp = require('amqplib');
+const certs = require('./certs');
+const config = require('../config');
+const log = require('../log')('idearium-lib:common/mq/rpc-client');
+const mq = require('../../lib/mq');
+
+const retryLimit = config.get('rabbitmqRetryLimit') || 10;
 
 /**
  * A common implement of mq.RPC to be used across many clients.
  */
 class RpcClient extends mq.RpcClient {
 
-    constructor(url, rpcTimeout) {
+    constructor (url, rpcTimeout) {
 
         // Make sure we have a URL to connect to RabbitMQ.
         if (!url) {
@@ -23,42 +27,91 @@ class RpcClient extends mq.RpcClient {
         this.reconnectCount = 0;
 
         // Once the certs have loaded, we'll update the options and connect.
-        certs.
-            then(this.makeConnection.bind(this));
+        certs.then((optionsCerts) => {
 
+            // Update options (for RabbitMQ connection) without certs.
+            Object.assign(this.options, optionsCerts);
+
+            // Connect even if there was an ENOENT error.
+            this.connect();
+
+        });
+
+    }
+
+    static logError (err) {
+        log.error({ err }, err.message);
+    }
+
+    reconnect () {
+        super.reconnect(parseInt(Math.pow(2, this.reconnectCount += 1), 10) * 1000);
     }
 
     /**
-     * This is merge the optionsCerts argument into this.options and
-     * attempt to make a connection to Rabbit.
-     * @param  {Object} optionsCerts Any certs required for connection.
-     * @return Void
+     * Establish a connection to RabbitMQ and attempt to reconnect if it fails.
+     * @param {String} url The RabbitMQ url.
+     * @return {Void} Connects to MQ.
      */
-    makeConnection (optionsCerts) {
+    connect () {
 
-        // Update options (for RabbitMQ connection) without certs.
-        Object.assign(this.options, optionsCerts || {});
+        // We don't need to connect if we already are.
+        if (this.state === 'connected' || this.state === 'connecting') {
+            return;
+        }
 
-        // Connect even if there was an ENOENT error.
-        this.connect();
+        // Update the state
+        this.state = 'connecting';
+
+        // Delay for 1 second to precent TLS errors on startup.
+        setTimeout(() => {
+
+            amqp.connect(this.mqUrl, this.options)
+                .then((conn) => {
+
+                    // Handle dropped connections.
+                    conn.on('close', () => {
+
+                        log.info('RabbitMQ connection dropped, retrying...');
+
+                        this.retry();
+
+                    });
+
+                    conn.on('error', (err) => {
+
+                        log.error({ err }, err.message);
+
+                        this.retry();
+
+                    });
+
+                    this.hasConnected(conn);
+
+                })
+                .catch((err) => {
+
+                    log.error({ err }, err.message);
+
+                    this.retry();
+
+                });
+
+        }, 1000);
 
     }
 
-    //
-    // Overwrite MqClient class methods.
-    //
+    retry () {
 
-    // Log using debug.
-    logError(err) {
-        // eslint-disable-next-line no-console
-        console.error(err.toString());
-    }
+        if (this.reconnectCount >= retryLimit) {
 
-    // Customise the reconnect timeout based on connection attempts.
-    reconnect() {
+            log.fatal('Retry limit reached, could not connect to RabbitMQ');
 
-        // set timeout to the power of 2
-        super.reconnect(parseInt(Math.pow(2, this.reconnectCount++)) * 1000);
+            // eslint-disable-next-line no-process-exit
+            return process.exit(1);
+
+        }
+
+        this.reconnect();
 
     }
 

--- a/idearium-lib/common/mq/rpc-client.js
+++ b/idearium-lib/common/mq/rpc-client.js
@@ -104,7 +104,7 @@ class RpcClient extends mq.RpcClient {
 
         if (this.reconnectCount >= retryLimit) {
 
-            log.fatal('Retry limit reached, could not connect to RabbitMQ');
+            log.fatal(`Retry limit of ${retryLimit} reached, could not connect to RabbitMQ`);
 
             // eslint-disable-next-line no-process-exit
             return process.exit(1);

--- a/idearium-lib/common/mq/rpc-server.js
+++ b/idearium-lib/common/mq/rpc-server.js
@@ -80,7 +80,7 @@ class RpcServer extends mq.RpcServer {
         // Update the state
         this.state = 'connecting';
 
-        // Delay for 1 second to precent TLS errors on startup.
+        // Delay for 1 second to prevent TLS errors on startup.
         setTimeout(() => {
 
             amqp.connect(this.mqUrl, this.options)

--- a/idearium-lib/common/mq/rpc-server.js
+++ b/idearium-lib/common/mq/rpc-server.js
@@ -122,7 +122,7 @@ class RpcServer extends mq.RpcServer {
 
         if (this.reconnectCount >= retryLimit) {
 
-            log.fatal('Retry limit reached, could not connect to RabbitMQ');
+            log.fatal(`Retry limit of ${retryLimit} reached, could not connect to RabbitMQ`);
 
             // eslint-disable-next-line no-process-exit
             return process.exit(1);

--- a/idearium-lib/common/mq/rpc-server.js
+++ b/idearium-lib/common/mq/rpc-server.js
@@ -1,15 +1,19 @@
 'use strict';
 
-var mq = require('../../lib/mq'),
-    config = require('../config'),
-    certs = require('./certs');
+const amqp = require('amqplib');
+const certs = require('./certs');
+const config = require('../config');
+const log = require('../log')('idearium-lib:common/mq/rpc-server');
+const mq = require('../../lib/mq');
+
+const retryLimit = config.get('rabbitmqRetryLimit') || 10;
 
 /**
  * A common implement of mq.RPC to be used across many clients.
  */
 class RpcServer extends mq.RpcServer {
 
-    constructor(name, callback) {
+    constructor (name, callback) {
 
         // Make sure we have a URL to connect to RabbitMQ.
         if (!config.get('mqUrl')) {
@@ -32,43 +36,100 @@ class RpcServer extends mq.RpcServer {
         // We'll customise the reconnection strategy from MqClient.
         this.reconnectCount = 0;
 
-        // Once the certs have loaded, we'll update the options and connect.
-        certs.
-            then(this.makeConnection.bind(this));
+        this.on('connect', () => {
 
+            // Reset the count and reconnect.
+            this.reconnectCount = 0;
+            this.setupRpc();
+
+        });
+
+        // Once the certs have loaded, we'll update the options and connect.
+        certs.then((optionsCerts) => {
+
+            // Update options (for RabbitMQ connection) without certs.
+            Object.assign(this.options, optionsCerts);
+
+            // Connect even if there was an ENOENT error.
+            this.connect();
+
+        });
+
+    }
+
+    static logError (err) {
+        log.error({ err }, err.message);
+    }
+
+    reconnect () {
+        super.reconnect(parseInt(Math.pow(2, this.reconnectCount += 1), 10) * 1000);
     }
 
     /**
-     * This is merge the optionsCerts argument into this.options and
-     * attempt to make a connection to Rabbit.
-     * @param  {Object} optionsCerts Any certs required for connection.
-     * @return Void
+     * Establish a connection to RabbitMQ and attempt to reconnect if it fails.
+     * @param {String} url The RabbitMQ url.
+     * @return {Void} Connects to MQ.
      */
-    makeConnection (optionsCerts) {
+    connect () {
 
-        // Update options (for RabbitMQ connection) without certs.
-        Object.assign(this.options, optionsCerts || {});
+        // We don't need to connect if we already are.
+        if (this.state === 'connected' || this.state === 'connecting') {
+            return;
+        }
 
-        // Connect even if there was an ENOENT error.
-        this.connect();
+        // Update the state
+        this.state = 'connecting';
+
+        // Delay for 1 second to precent TLS errors on startup.
+        setTimeout(() => {
+
+            amqp.connect(this.mqUrl, this.options)
+                .then((conn) => {
+
+                    // Handle dropped connections.
+                    conn.on('close', () => {
+
+                        log.info('RabbitMQ RPC connection dropped, retrying...');
+
+                        this.retry();
+
+                    });
+
+                    conn.on('error', (err) => {
+
+                        log.error({ err }, err.message);
+
+                        this.retry();
+
+                    });
+
+                    this.hasConnected(conn);
+
+                })
+                .catch((err) => {
+
+                    log.error({ err }, err.message);
+
+                    this.retry();
+
+                });
+
+        }, 1000);
 
     }
 
-    //
-    // Overwrite MqClient class methods.
-    //
+    retry () {
 
-    // Log using debug.
-    logError(err) {
-        // eslint-disable-next-line no-console
-        console.error(err.toString());
-    }
+        if (this.reconnectCount >= retryLimit) {
 
-    // Customise the reconnect timeout based on connection attempts.
-    reconnect() {
+            log.fatal('Retry limit reached, could not connect to RabbitMQ');
 
-        // set timeout to the power of 2
-        super.reconnect(parseInt(Math.pow(2, this.reconnectCount++)) * 1000);
+            // eslint-disable-next-line no-process-exit
+            return process.exit(1);
+
+        }
+
+        this.reconnect();
 
     }
 

--- a/idearium-lib/test/common-mq-client.test.js
+++ b/idearium-lib/test/common-mq-client.test.js
@@ -2,7 +2,12 @@
 
 'use strict';
 
-jest.mock('/app/config/config.js', () => ({ env: 'test' }));
+jest.mock('/app/config/config.js', () => ({
+    env: 'test',
+    logLevel: 'debug',
+    logLocation: 'local',
+    logToStdout: true,
+}));
 
 let path = require('path'),
     copy = require('copy-dir'),

--- a/idearium-lib/test/common-rpc-server.test.js
+++ b/idearium-lib/test/common-rpc-server.test.js
@@ -2,7 +2,12 @@
 
 'use strict';
 
-jest.mock('/app/config/config.js', () => ({ env: 'test' }));
+jest.mock('/app/config/config.js', () => ({
+    env: 'test',
+    logLevel: 'debug',
+    logLocation: 'local',
+    logToStdout: true,
+}));
 
 let path = require('path'),
     copy = require('copy-dir'),

--- a/idearium-lib/test/rpc.test.js
+++ b/idearium-lib/test/rpc.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 jest.mock('/app/config/config.js', () => ({
+    logLevel: 'debug',
+    logLocation: 'local',
+    logToStdout: true,
     mqRpcClientTimeout: 10000,
     mqUrl: require('./conf').rabbitUrl,
 }));


### PR DESCRIPTION
This PR allows RabbitMQ to retry dropped connections.

## Setup

- [ ] Add this to some projects that use mq + rpc (client and server).

## Testing

- [ ] Run the project and simulate a dropped connection (close your local mq infrastructure).
- [ ] Wait for the retries to hit the limit (defaults to 10 although you can set `rabbitmqRetryLimit` in your configs to a lower number). It should fail with a retry limit reached log.
- [ ] Start your mq infrastructure again and restart the containers.
- [ ] Stop the mq infrastructure again and then start it. You should notices the mq connected logs.

## Notes

- This is currently on the AB beta sites.