### PR TITLE
Fetch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ All the libraries are stored under `packages/*`. We currently have the following
 
 -   `@idearium/apm` - Defaults for our Elastic APM integration.
 -   `@idearium/encryption` - Making it painless to encrypt and decrypt plain text.
+-   `@idearium/fetch` - Making fetch requests easy.
 -   `@idearium/lists` - Manage multiple lists of information and retrieve the data in various formats.
 -   `@idearium/log` - To manage application logging and optionally log to a remote server (InsightOps).

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/fetch
 
-## Unreleased
+## v1.0.1-beta.1
 
 -   You can now provide fetch parameters to configure the fetch request.
 

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @idearium/fetch
+
+## Unreleased
+
+-   You can now provide fetch parameters to configure the fetch request.
+
+## v1.0.0
+
+-   First version of the package.

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,9 +1,11 @@
 # @idearium/fetch
 
-## v1.0.1-beta.1
+## v1.0.1
 
 -   You can now provide fetch parameters to configure the fetch request.
 
 ## v1.0.0
 
 -   First version of the package.
+
+@idearium/fetch-v1.0.1-beta.1

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -22,11 +22,12 @@ const parseResponse = async (response) => {
     return { ok, result, status };
 };
 
-const fetchApi = async (url, { headers } = {}) =>
-    parseResponse(
-        await fetch(url, {
-            headers: { 'content-type': 'application/json', ...headers }
-        })
-    );
+const fetchApi = async (url, { headers, ...options } = {}) => {
+    const opts = { ...options };
+
+    opts.headers = { 'content-type': 'application/json', ...headers };
+
+    return parseResponse(await fetch(url, opts));
+};
 
 module.exports = fetchApi;

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/fetch",
-    "version": "1.0.1-beta.1",
+    "version": "1.0.1",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,10 +1,13 @@
 {
     "name": "@idearium/fetch",
-    "version": "1.0.0",
+    "version": "1.0.1-beta.1",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",
-    "author": "Allan Chau <allan@idearium.io>",
+    "contributors": [
+        "Allan Chau <allan@idearium.io>",
+        "Scott Mebberson <scott@idearium.io>"
+    ],
     "license": "MIT",
     "scripts": {
         "test": "jest"

--- a/packages/fetch/tests/index.test.js
+++ b/packages/fetch/tests/index.test.js
@@ -6,6 +6,7 @@ const fetchMock = require('isomorphic-fetch');
 const fetchApi = require('../');
 
 const testUrl = 'http://www.idearium.io/';
+const headers = { 'content-type': 'application/json' };
 
 beforeEach(() => {
     fetchMock.mockClear();
@@ -34,4 +35,72 @@ it('returns a tuple for error requests', async () => {
     fetchMock.get(testUrl, 400);
 
     await expect(fetchApi(testUrl)).rejects.toEqual(new Error('Bad Request'));
+});
+
+it('automatically sets the content-type header', async () => {
+    expect.assertions(1);
+
+    const headers = { 'content-type': 'application/json' };
+
+    fetchMock.mock(testUrl, [], {
+        headers
+    });
+
+    await fetchApi(testUrl);
+
+    await expect(fetchMock).toHaveBeenCalledWith(testUrl, {
+        headers
+    });
+});
+
+it('allows POST requests', async () => {
+    expect.assertions(1);
+
+    fetchMock.mock(testUrl, [], {
+        headers,
+        method: 'POST'
+    });
+
+    await fetchApi(testUrl, { method: 'POST' });
+
+    await expect(fetchMock).toHaveBeenCalledWith(testUrl, {
+        headers,
+        method: 'POST'
+    });
+});
+
+it('allows fetch parameters', async () => {
+    expect.assertions(1);
+
+    const credentials = 'same-origin';
+
+    fetchMock.mock(testUrl, [], {
+        credentials,
+        headers
+    });
+
+    await fetchApi(testUrl, { credentials });
+
+    expect(fetchMock).toHaveBeenCalledWith(testUrl, {
+        credentials,
+        headers
+    });
+});
+
+it('allows multiple fetch parameters', async () => {
+    expect.assertions(1);
+
+    const cache = 'no-store';
+    const credentials = 'same-origin';
+    const opts = {
+        cache,
+        credentials,
+        headers
+    };
+
+    fetchMock.mock(testUrl, [], opts);
+
+    await fetchApi(testUrl, { cache, credentials });
+
+    expect(fetchMock).toHaveBeenCalledWith(testUrl, opts);
 });


### PR DESCRIPTION
This PR improves `@idearium/fetch` by allowing all [fetch parameters](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) to be used. Prior to this, only the `headers` parameter would work.

## Testing

- [x] Review the code.
- [x] Ensure the tests accurately cover the new development, and work.
