### PR TITLE
Remove ok check

### DIFF
--- a/docusaurus/docs/fetch.md
+++ b/docusaurus/docs/fetch.md
@@ -23,7 +23,7 @@ $ yarn add -E @idearium/fetch@beta
 
 To use `@idearium/fetch`, simply require it at the top of your file.
 
-It is simply a fetch wrapper that automatically parses the body response into a property `result.
+It is simply a fetch wrapper that automatically parses the body response into a property `result`.
 
 ```js
 const { ...response, result } = await fetch('...', { fetchOpts });

--- a/docusaurus/docs/fetch.md
+++ b/docusaurus/docs/fetch.md
@@ -1,0 +1,30 @@
+---
+id: fetch
+title: '@idearium/fetch'
+---
+
+Idearium fetch wrapper.
+
+## Installation
+
+```shell
+$ yarn add -E @idearium/fetch
+```
+
+### Beta installation
+
+If you need to install a beta version, you can:
+
+```shell
+$ yarn add -E @idearium/fetch@beta
+```
+
+## Usage
+
+To use `@idearium/fetch`, simply require it at the top of your file.
+
+It is simply a fetch wrapper that automatically parses the body response into a property `result.
+
+```js
+const { ...response, result } = await fetch('...', { fetchOpts });
+```

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @idearium/fetch
 
+## v2.0.2
+
+### Changed
+
+-   Re-release with updated version number.
+
 ## v2.0.1
 
 ### Changed

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/fetch
 
-## v2.0.0-beta.1
+## v2.0.0
 
 ### Removed
 

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @idearium/fetch
 
+## v2.0.1
+
+### Changed
+
+-   Re-release with updated version number.
+
 ## v2.0.0
 
 ### Removed

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @idearium/fetch
 
+## v2.0.0-beta.1
+
+### Removed
+
+-   Removed the `!ok` check. It is now up to the user to handle any errors and `!ok` statuses.
+
 ## v1.0.1
 
 -   You can now provide fetch parameters to configure the fetch request.

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -11,15 +11,9 @@ const parseBody = (response) => {
 };
 
 const parseResponse = async (response) => {
-    const { ok, status } = response;
+    response.result = await parseBody(response);
 
-    if (!ok) {
-        throw new Error(response.statusText);
-    }
-
-    const result = await parseBody(response);
-
-    return { ok, result, status };
+    return response;
 };
 
 const fetchApi = async (url, { headers, ...options } = {}) => {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/fetch",
-    "version": "1.0.1",
+    "version": "2.0.0-beta.1",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/fetch",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/fetch",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.1",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/fetch/tests/index.test.js
+++ b/packages/fetch/tests/index.test.js
@@ -22,7 +22,7 @@ it('returns a tuple for successful requests', async () => {
 
     fetchMock.get(testUrl, { pass: true });
 
-    await expect(fetchApi(testUrl)).resolves.toEqual({
+    await expect(fetchApi(testUrl)).resolves.toMatchObject({
         ok: true,
         result: { pass: true },
         status: 200
@@ -32,9 +32,17 @@ it('returns a tuple for successful requests', async () => {
 it('returns a tuple for error requests', async () => {
     expect.assertions(1);
 
-    fetchMock.get(testUrl, 400);
+    fetchMock.get(testUrl, {
+        body: { pass: false },
+        headers,
+        status: 400
+    });
 
-    await expect(fetchApi(testUrl)).rejects.toEqual(new Error('Bad Request'));
+    await expect(fetchApi(testUrl)).resolves.toMatchObject({
+        ok: false,
+        result: { pass: false },
+        status: 400
+    });
 });
 
 it('automatically sets the content-type header', async () => {

--- a/packages/fetch/tests/index.test.js
+++ b/packages/fetch/tests/index.test.js
@@ -45,6 +45,22 @@ it('returns a tuple for error requests', async () => {
     });
 });
 
+it('result contains the main response properties', async () => {
+    expect.assertions(6);
+
+    fetchMock.get(testUrl, {});
+
+    const response = await fetchApi(testUrl);
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response#properties
+    expect(response).toHaveProperty('headers');
+    expect(response).toHaveProperty('ok');
+    expect(response).toHaveProperty('redirected');
+    expect(response).toHaveProperty('status');
+    expect(response).toHaveProperty('statusText');
+    expect(response).toHaveProperty('url');
+});
+
 it('automatically sets the content-type header', async () => {
     expect.assertions(1);
 


### PR DESCRIPTION
This PR removed the `!ok` logic from the fetch library.

**Setup**

- [x] Include the latest beta tag into one of your projects.

**Testing**

- [x] Create an api that returns a 404 with a response body.
- [x] Make sure the response body is available in the `result` property.
