### PR TITLE
@idearium/log updates and first version of @idearium/log-insightops.

### DIFF
--- a/.github/workflows/log-insightops.yml
+++ b/.github/workflows/log-insightops.yml
@@ -1,0 +1,79 @@
+name: '@idearium/log-insightops'
+on:
+    push:
+        paths:
+            - 'packages/log-insightops/**'
+    release:
+        types: [published]
+
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Setup Node.js
+              uses: actions/setup-node@v1
+            - name: Get yarn cache
+              id: yarn-cache
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Cache yarn
+              uses: actions/cache@v1
+              with:
+                  path: ${{ steps.yarn-cache.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+            - name: Cache node_modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node_modules-
+            - name: Setup yarn
+              run: yarn install
+            - name: Test
+              run: yarn workspace @idearium/log-insightops test
+    publish:
+        if: github.event_name == 'release' && contains(github.ref, '@idearium/log-insightops')
+        name: Publish
+        needs: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Setup Node.js
+              uses: actions/setup-node@v1
+              with:
+                  registry-url: https://registry.npmjs.org/
+            - name: Get yarn cache
+              id: yarn-cache
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Cache yarn
+              uses: actions/cache@v1
+              with:
+                  path: ${{ steps.yarn-cache.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+            - name: Cache node_modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node_modules-
+            - name: Setup yarn
+              run: yarn install
+            - name: Publish (beta)
+              if: contains(github.ref, 'beta')
+              run: yarn workspace @idearium/log-insightops publish --tag beta --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Publish
+              if: "!contains(github.ref , 'beta')"
+              run: yarn workspace @idearium/log-insightops publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.words": ["serializers"]
+}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+--install.ignore-platform true
+--install.ignore-optional true

--- a/docusaurus/docs/log-insightops.md
+++ b/docusaurus/docs/log-insightops.md
@@ -17,7 +17,7 @@ The Idearium logger InsightOps transport takes log output from [`@idearium/log`]
 
 To do so, you will need the configure some environment variables:
 
--   `INSIGHT_OPS_REGION` - The InsightOps region (`eu`).
+-   `INSIGHT_OPS_REGION` - The InsightOps region.
 -   `INSIGHT_OPS_TOKEN` - The InsightOps token.
 
 Then start your Node application and pipe the output to the `insightops` script (found at `node_modules/.bin/insightops` once this package is installed):

--- a/docusaurus/docs/log-insightops.md
+++ b/docusaurus/docs/log-insightops.md
@@ -1,0 +1,35 @@
+---
+id: log-insightops
+title: '@idearium/log-insightops'
+---
+
+The Idearium logger InsightOps transport.
+
+## Installation
+
+```shell
+$ yarn add @idearium/log-insightops
+```
+
+## Usage
+
+The Idearium logger InsightOps transport takes log output from [`@idearium/log`](https://idearium.github.io/idearium-lib/docs/log) and sends it to InsightOps.
+
+To do so, you will need the configure some environment variables:
+
+-   `INSIGHT_OPS_REGION` - The InsightOps region (`eu`).
+-   `INSIGHT_OPS_TOKEN` - The InsightOps token.
+
+Then start your Node application and pipe the output to the `insightops` script (found at `node_modules/.bin/insightops` once this package is installed):
+
+```shell
+$ node server.js | insightops
+```
+
+### Combining Transports
+
+Sometimes you will want to use multiple transports. To do this you can use the `tee` command in bash:
+
+```shell
+$ node server.js | tee insightops pino-stackdriver --project bar --credentials /credentials.json
+```

--- a/docusaurus/docs/log.md
+++ b/docusaurus/docs/log.md
@@ -17,10 +17,30 @@ $ yarn add @idearium/log
 const log = require('@idearium/log')();
 
 log.info('A simple example of @idearium/log');
+```
 
+The above produces the following log output:
+
+```
+{
+    level: 30,
+    severity: 'INFO',
+    time: '2021-05-05T04:17:45.096Z',
+    'logging.googleapis.com/sourceLocation': {
+        file: '/tests/index.test.js'
+    },
+    message: 'A simple example of @idearium/log'
+}
 ```
 
 ### Configuration
+
+There are two methods to configure the Idearium logger:
+
+-   Using predefined environment variables for the most common configurations.
+-   Using an options object for complete customisation.
+
+#### Environment variables
 
 The Idearium logger can be configured with environment variables:
 
@@ -28,6 +48,14 @@ The Idearium logger can be configured with environment variables:
 -   `LOG_LEVEL` - The minimum log level to log. Defaults to `info`. Other accepted values are `trace | debug | info | warn | error | fatal`.
 -   `LOG_PRETTY_PRINT` - Whether to pretty print the logs or not, useful for development. Defaults to `false`.
 -   `LOG_REDACT_PATHS` - Optionally provide a comma separated list of paths to redact. [https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax](https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax)
+
+#### Options
+
+Please be aware that the Idearium Logger has been setup to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging) and that altering any of the options could reduce the effectiveness of that integration.
+
+**`sourceLocation`**
+
+By default the logger will determine the file in which the log took place and put this information in the `logging.googleapis.com/sourceLocation` property. You can customise this by providing the `sourceLocation` option.
 
 Further to this, you can pass in any [options supported by Pino](https://getpino.io/#/docs/api?id=options).
 

--- a/docusaurus/docs/log.md
+++ b/docusaurus/docs/log.md
@@ -26,8 +26,8 @@ The Idearium logger can be configured with environment variables:
 
 -   `LOG_ENABLED` - Whether to enable the logger or not. Defaults to `true`.
 -   `LOG_LEVEL` - The minimum log level to log. Defaults to `info`. Other accepted values are `trace | debug | info | warn | error | fatal`.
--   `PINO_PRETTY_PRINT` - Whether to pretty print the logs or not, useful for development. Defaults to `false`.
--   `PINO_REDACT_PATHS` - Optionally provide a comma separated list of paths to redact. [https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax](https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax)
+-   `LOG_PRETTY_PRINT` - Whether to pretty print the logs or not, useful for development. Defaults to `false`.
+-   `LOG_REDACT_PATHS` - Optionally provide a comma separated list of paths to redact. [https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax](https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax)
 
 Further to this, you can pass in any [options supported by Pino](https://getpino.io/#/docs/api?id=options).
 

--- a/docusaurus/docs/log.md
+++ b/docusaurus/docs/log.md
@@ -3,7 +3,7 @@ id: log
 title: '@idearium/log'
 ---
 
-The Idearium logger.
+The Idearium JSON logger. Uses [Pino](https://getpino.io/) under the hood.
 
 ## Installation
 
@@ -13,32 +13,24 @@ $ yarn add @idearium/log
 
 ## Usage
 
-The Idearium logger takes the following environment variables:
+```JavaScript
+const log = require('@idearium/log')();
+
+log.info('A simple example of @idearium/log');
+
+```
+
+### Configuration
+
+The Idearium logger can be configured with environment variables:
 
 -   `LOG_ENABLED` - Whether to enable the logger or not. Defaults to `true`.
 -   `LOG_LEVEL` - The minimum log level to log. Defaults to `info`. Other accepted values are `trace | debug | info | warn | error | fatal`.
--   `PINO_PRETTY_PRINT` - Whether to pretty print the logs or not, useful for development. Defaults to `true`.
+-   `PINO_PRETTY_PRINT` - Whether to pretty print the logs or not, useful for development. Defaults to `false`.
 -   `PINO_REDACT_PATHS` - Optionally provide a comma separated list of paths to redact. [https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax](https://github.com/pinojs/pino/blob/master/docs/redaction.md#path-syntax)
 
-### InsightOps
+Further to this, you can pass in any [options supported by Pino](https://getpino.io/#/docs/api?id=options).
 
-If you wish to log to a remote server (InsightOps), you will need the following variables:
+## Transports
 
--   `LOG_REMOTE` - Whether to log to a remote server or not. Setting this to `true` will disable pretty printing.
--   `INSIGHT_OPS_REGION` - The InsightOps region (`eu`).
--   `INSIGHT_OPS_TOKEN` - The InsightOps token.
-
-Since Pino does not natively support in process transports, we expose a `insightops` logging script to send logs to InsightOps.
-To use this, simply provide the necessary variables above and start the node process:
-
-```shell
-$ node server.js | insightops
-```
-
-### Combining Transports
-
-Sometimes you will want to use multiple transports. To do this you can use the `tee` command in bash:
-
-```shell
-$ node server.js | tee insightops pino-stackdriver --project bar --credentials /credentials.json
-```
+The Idearium logger does not support transports out of the box. See [@idearium/log-insightops](https://idearium.github.io/idearium-lib/docs/log) for a transport for InsightOps.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -9,6 +9,7 @@ module.exports = {
             'fetch',
             'lists',
             'log',
+            'log-insightops',
             'mongoose',
             'utils'
         ]

--- a/packages/log-insightops/CHANGELOG.md
+++ b/packages/log-insightops/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @idearium/log-insightops
+
+## v1.0.0-beta.1
+
+-   First version of the package.

--- a/packages/log-insightops/CHANGELOG.md
+++ b/packages/log-insightops/CHANGELOG.md
@@ -1,5 +1,6 @@
 # @idearium/log-insightops
 
-## v1.0.0-beta.1
+## v1.0.0
 
 -   First version of the package.
+-   Sends logs from @idearium/log to InsightOps.

--- a/packages/log-insightops/README.md
+++ b/packages/log-insightops/README.md
@@ -1,0 +1,5 @@
+# @idearium/log-insightops
+
+The Idearium logger InsightOps transport.
+
+To find out more, read the [documentation for @idearium/log-insighops](https://idearium.github.io/idearium-lib/docs/log-insighops).

--- a/packages/log-insightops/bin/insightops.js
+++ b/packages/log-insightops/bin/insightops.js
@@ -6,23 +6,16 @@ const pump = require('pump');
 const split = require('split2');
 
 /* eslint-disable no-process-env */
-// Just return what was passed.
-if (process.env.LOG_REMOTE !== 'true') {
-    return pump(process.stdin, process.stdout);
-}
-/* eslint-enable no-process-env */
-
-/* eslint-disable no-process-env */
 const region = process.env.INSIGHT_OPS_REGION;
 const token = process.env.INSIGHT_OPS_TOKEN;
 /* eslint-enable no-process-env */
 
 if (!region) {
-    throw new Error('A region is required!');
+    throw new Error('A region is required');
 }
 
 if (!token) {
-    throw new Error('A token is required!');
+    throw new Error('A token is required');
 }
 
 const { stream } = Logger.bunyanStream({

--- a/packages/log-insightops/package.json
+++ b/packages/log-insightops/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@idearium/log-insightops",
+    "version": "1.0.0-beta.1",
+    "description": "Idearium logger insightops transport",
+    "repository": "https://github.com/idearium/idearium-lib",
+    "author": "Scott Mebberson <scott@idearium.io>",
+    "license": "MIT",
+    "bin": {
+        "insightops": "bin/insightops.js"
+    },
+    "scripts": {
+        "test": "jest"
+    },
+    "dependencies": {
+        "pump": "3.0.0",
+        "r7insight_node": "1.8.3",
+        "split2": "3.2.2"
+    }
+}

--- a/packages/log-insightops/package.json
+++ b/packages/log-insightops/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log-insightops",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0",
     "description": "Idearium logger insightops transport",
     "repository": "https://github.com/idearium/idearium-lib",
     "author": "Scott Mebberson <scott@idearium.io>",

--- a/packages/log-insightops/tests/index.test.js
+++ b/packages/log-insightops/tests/index.test.js
@@ -69,6 +69,6 @@ test('logs to a remote server', async () => {
     const result = await once(stream, 'data');
 
     // If this isn't working, sink would throw an error due to JSON.parse trying to parse the prettyfied log.
-    expect(result.msg).toBe('test');
+    expect(result.message).toBe('test');
 });
 /* eslint-enable no-process-env,global-require */

--- a/packages/log-insightops/tests/index.test.js
+++ b/packages/log-insightops/tests/index.test.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-process-env,global-require */
+'use strict';
+
+const processEnv = process.env;
+
+const once = (emitter, name) =>
+    new Promise((resolve, reject) => {
+        if (name !== 'error') {
+            emitter.once('error', reject);
+        }
+
+        emitter.once(name, (...args) => {
+            emitter.removeListener('error', reject);
+            resolve(...args);
+        });
+    });
+
+const sink = () => {
+    const split = require('split2');
+
+    const result = split((data) => {
+        try {
+            return JSON.parse(data);
+        } catch (err) {
+            console.log(err);
+            console.log(data);
+        }
+    });
+
+    return result;
+};
+
+beforeEach(() => {
+    jest.resetModules();
+    process.env = Object.assign({}, processEnv);
+});
+
+afterEach(() => {
+    process.env = processEnv;
+});
+
+test('throws if INSIGHT_OPS_REGION is not set', () => {
+    expect(() => require('../bin/insightops')).toThrow('A region is required');
+});
+
+test('throws if INSIGHT_OPS_TOKEN is not set', () => {
+    process.env.INSIGHT_OPS_REGION = 'eu';
+
+    expect(() => require('../bin/insightops')).toThrow('A token is required');
+});
+
+test('is okay if all environment variables are set', () => {
+    process.env.INSIGHT_OPS_REGION = 'eu';
+    process.env.INSIGHT_OPS_TOKEN = '123';
+
+    expect(() => require('../bin/insightops')).not.toThrow(
+        'A token is required'
+    );
+});
+
+test('logs to a remote server', async () => {
+    expect.assertions(1);
+
+    const stream = sink();
+    const log = require('../../log')({ stream });
+
+    log.info('test');
+
+    const result = await once(stream, 'data');
+
+    // If this isn't working, sink would throw an error due to JSON.parse trying to parse the prettyfied log.
+    expect(result.msg).toBe('test');
+});
+/* eslint-enable no-process-env,global-require */

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @idearium/log
 
+## Unreleased
+
+-   Automated the inclusion of the `sourceLocation` property.
+
 ## v1.0.0-beta.4 - 2021-05-04
 
 -   Deprecated the use of `require-main-filename`.

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/log
 
-## Unreleased
+## v1.0.0-beta.6 - 2021-05-05
 
 -   Refined the automatic `sourceLocation` result.
 -   Updated `msg` to be `message` to support GCP structured logging.

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -5,6 +5,8 @@
 -   Dependency upgrades.
 -   Deprecated `insightops` from this package (see @idearium/log-insightops).
 -   Deprecated `LOG_REMOTE`.
+-   Renamed `PINO_PRETTY_PRINT` to `LOG_PRETTY_PRINT`.
+-   Renamed `PINO_REDACT_PATHS` to `LOG_REDACT_PATHS`.
 -   Pretty printing now needs to be explicitly enabled.
 
 ## v1.0.0-beta.1

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @idearium/log
 
-## Unreleased
+## v1.0.0-beta.3 - 2021-05-04
 
 -   Added `severity` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
 -   Updated `time` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
 
-## v1.0.0-beta.2
+## v1.0.0-beta.2 - 2021-05-04
 
 -   Dependency upgrades.
 -   Deprecated `insightops` from this package (see @idearium/log-insightops).

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @idearium/log
 
+## Unreleased
+
+-   Deprecated the use of `require-main-filename`.
+-   `context` now uses `__dirname` and `__filename`.
+
 ## v1.0.0-beta.3 - 2021-05-04
 
 -   Added `severity` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @idearium/log
 
+## Unreleased
+
+-   Refined the automatic `sourceLocation` result.
+
 ## v1.0.0-beta.5 - 2021-05-05
 
 -   Automated the inclusion of the `sourceLocation` property.

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
--   Added severity to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
+-   Added `severity` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
+-   Updated `time` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
 
 ## v1.0.0-beta.2
 

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/log
 
-## Unreleased
+## v1.0.0-beta.4 - 2021-05-04
 
 -   Deprecated the use of `require-main-filename`.
 -   `context` now uses `__dirname` and `__filename`.

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,33 +1,6 @@
 # @idearium/log
 
-## v1.0.0-beta.6 - 2021-05-05
-
--   Refined the automatic `sourceLocation` result.
--   Updated `msg` to be `message` to support GCP structured logging.
-
-## v1.0.0-beta.5 - 2021-05-05
-
--   Automated the inclusion of the `sourceLocation` property to support GCP structured logging.
-
-## v1.0.0-beta.4 - 2021-05-04
-
--   Deprecated the use of `require-main-filename`.
--   `context` now uses `__dirname` and `__filename`.
-
-## v1.0.0-beta.3 - 2021-05-04
-
--   Added `severity` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
--   Updated `time` to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
-
-## v1.0.0-beta.2 - 2021-05-04
-
--   Dependency upgrades.
--   Deprecated `insightops` from this package (see @idearium/log-insightops).
--   Deprecated `LOG_REMOTE`.
--   Renamed `PINO_PRETTY_PRINT` to `LOG_PRETTY_PRINT`.
--   Renamed `PINO_REDACT_PATHS` to `LOG_REDACT_PATHS`.
--   Pretty printing now needs to be explicitly enabled.
-
-## v1.0.0-beta.1
+## v1.0.0 - 2021-05-06
 
 -   First version of the package.
+-   Designed to work well with [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+-   Added severity to support [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging).
+
+## v1.0.0-beta.2
+
 -   Dependency upgrades.
 -   Deprecated `insightops` from this package (see @idearium/log-insightops).
 -   Deprecated `LOG_REMOTE`.

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/log
 
-## Unreleased
+## v1.0.0-beta.5 - 2021-05-05
 
 -   Automated the inclusion of the `sourceLocation` property.
 

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Unreleased
 
 -   Refined the automatic `sourceLocation` result.
+-   Updated `msg` to be `message` to support GCP structured logging.
 
 ## v1.0.0-beta.5 - 2021-05-05
 
--   Automated the inclusion of the `sourceLocation` property.
+-   Automated the inclusion of the `sourceLocation` property to support GCP structured logging.
 
 ## v1.0.0-beta.4 - 2021-05-04
 

--- a/packages/log/CHANGELOG.md
+++ b/packages/log/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @idearium/log
 
+## Unreleased
+
+-   Dependency upgrades.
+-   Deprecated `insightops` from this package (see @idearium/log-insightops).
+-   Deprecated `LOG_REMOTE`.
+-   Pretty printing now needs to be explicitly enabled.
+
 ## v1.0.0-beta.1
 
 -   First version of the package.

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -35,6 +35,7 @@ const defaults = {
         level: levelFormatter
     },
     level: process.env.LOG_LEVEL || 'info',
+    messageKey: 'message',
     prettyPrint: process.env.LOG_PRETTY_PRINT === 'true',
     redact: process.env.LOG_REDACT_PATHS
         ? redactPathsDefaults.concat(process.env.LOG_REDACT_PATHS.split(','))

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -12,11 +12,10 @@ const redactPathsDefaults = [
 
 /* eslint-disable no-process-env */
 const defaults = {
+    base: null,
     enabled: process.env.LOG_ENABLED !== 'false',
     level: process.env.LOG_LEVEL || 'info',
-    prettyPrint:
-        process.env.LOG_REMOTE !== 'true' &&
-        process.env.PINO_PRETTY_PRINT !== 'false',
+    prettyPrint: process.env.PINO_PRETTY_PRINT === 'true',
     redact: process.env.PINO_REDACT_PATHS
         ? redactPathsDefaults.concat(process.env.PINO_REDACT_PATHS.split(','))
         : redactPathsDefaults,

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -59,6 +59,5 @@ module.exports = (options = {}) =>
                         !s.includes('node_modules\\pino')
                 )[0]
                 .match(/\((.*?):/)[1]
-                .replace(__dirname, '')
         }
     });

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -38,7 +38,8 @@ const defaults = {
     redact: process.env.LOG_REDACT_PATHS
         ? redactPathsDefaults.concat(process.env.LOG_REDACT_PATHS.split(','))
         : redactPathsDefaults,
-    serializers: pino.stdSerializers
+    serializers: pino.stdSerializers,
+    timestamp: pino.stdTimeFunctions.isoTime
 };
 /* eslint-enable no-process-env */
 

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -3,6 +3,17 @@
 const pino = require('pino');
 const main = require('require-main-filename')();
 
+const pinoLevelToSeverity = {
+    /* eslint-disable sort-keys */
+    trace: 'DEBUG',
+    debug: 'DEBUG',
+    info: 'INFO',
+    warn: 'WARNING',
+    error: 'ERROR',
+    fatal: 'CRITICAL'
+    /* eslint-enable sort-keys */
+};
+
 const redactPathsDefaults = [
     '*.member.password',
     '*.password',
@@ -10,10 +21,18 @@ const redactPathsDefaults = [
     'password'
 ];
 
+const levelFormatter = (label, number) => ({
+    level: number,
+    severity: pinoLevelToSeverity[label] || pinoLevelToSeverity.info
+});
+
 /* eslint-disable no-process-env */
 const defaults = {
     base: null,
     enabled: process.env.LOG_ENABLED !== 'false',
+    formatters: {
+        level: levelFormatter
+    },
     level: process.env.LOG_LEVEL || 'info',
     prettyPrint: process.env.LOG_PRETTY_PRINT === 'true',
     redact: process.env.LOG_REDACT_PATHS

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -15,9 +15,9 @@ const defaults = {
     base: null,
     enabled: process.env.LOG_ENABLED !== 'false',
     level: process.env.LOG_LEVEL || 'info',
-    prettyPrint: process.env.PINO_PRETTY_PRINT === 'true',
-    redact: process.env.PINO_REDACT_PATHS
-        ? redactPathsDefaults.concat(process.env.PINO_REDACT_PATHS.split(','))
+    prettyPrint: process.env.LOG_PRETTY_PRINT === 'true',
+    redact: process.env.LOG_REDACT_PATHS
+        ? redactPathsDefaults.concat(process.env.LOG_REDACT_PATHS.split(','))
         : redactPathsDefaults,
     serializers: pino.stdSerializers
 };

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const pino = require('pino');
-const main = require('require-main-filename')();
 
 const pinoLevelToSeverity = {
     /* eslint-disable sort-keys */
@@ -48,6 +47,6 @@ module.exports = (options = {}) => {
         Object.assign({}, defaults, options),
         options.stream || pino.destination(1)
     ).child({
-        context: main
+        context: __filename.replace(__dirname, '')
     });
 };

--- a/packages/log/index.js
+++ b/packages/log/index.js
@@ -2,6 +2,8 @@
 
 const pino = require('pino');
 
+const sourceLocationKey = 'logging.googleapis.com/sourceLocation';
+
 const pinoLevelToSeverity = {
     /* eslint-disable sort-keys */
     trace: 'DEBUG',
@@ -42,11 +44,21 @@ const defaults = {
 };
 /* eslint-enable no-process-env */
 
-module.exports = (options = {}) => {
-    return pino(
+module.exports = (options = {}) =>
+    pino(
         Object.assign({}, defaults, options),
         options.stream || pino.destination(1)
     ).child({
-        context: __filename.replace(__dirname, '')
+        [`${sourceLocationKey}`]: options.sourceLocation || {
+            file: Error()
+                .stack.split('\n')
+                .slice(2)
+                .filter(
+                    (s) =>
+                        !s.includes('node_modules/pino') &&
+                        !s.includes('node_modules\\pino')
+                )[0]
+                .match(/\((.*?):/)[1]
+                .replace(__dirname, '')
+        }
     });
-};

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -4,20 +4,20 @@
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",
-    "author": "Allan Chau <allan@idearium.io>",
+    "contributors": [
+        "Allan Chau <allan@idearium.io>",
+        "Scott Mebberson <scott@idearium.io>"
+    ],
     "license": "MIT",
-    "bin": {
-        "insightops": "bin/insightops.js"
-    },
     "scripts": {
         "test": "jest"
     },
     "dependencies": {
-        "pino": "5.13.4",
-        "pino-pretty": "3.2.1",
-        "pump": "3.0.0",
-        "r7insight_node": "1.8.3",
-        "require-main-filename": "2.0.0",
-        "split2": "3.1.1"
+        "pino": "6.11.3",
+        "pino-pretty": "4.7.1",
+        "require-main-filename": "2.0.0"
+    },
+    "devDependencies": {
+        "split2": "3.2.2"
     }
 }

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0-beta.2",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.5",
+    "version": "1.0.0-beta.6",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.3",
+    "version": "1.0.0-beta.4",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.2",
+    "version": "1.0.0-beta.3",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -14,8 +14,7 @@
     },
     "dependencies": {
         "pino": "6.11.3",
-        "pino-pretty": "4.7.1",
-        "require-main-filename": "2.0.0"
+        "pino-pretty": "4.7.1"
     },
     "devDependencies": {
         "split2": "3.2.2"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.6",
+    "version": "1.0.0",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log",
-    "version": "1.0.0-beta.4",
+    "version": "1.0.0-beta.5",
     "description": "Idearium logger",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/log/tests/index.test.js
+++ b/packages/log/tests/index.test.js
@@ -41,7 +41,7 @@ afterEach(() => {
 test('logs to the console', async () => {
     expect.assertions(2);
 
-    process.env.PINO_PRETTY_PRINT = 'false';
+    process.env.LOG_PRETTY_PRINT = 'false';
 
     const stream = sink();
     const log = require('../')({ stream });
@@ -84,11 +84,11 @@ test('only logs at the specified "LOG_LEVEL" and above', async () => {
     expect(log.fatal.name).toBe('');
 });
 
-test('redacts paths specified in "PINO_REDACT_PATHS"', async () => {
+test('redacts paths specified in "LOG_REDACT_PATHS"', async () => {
     expect.assertions(1);
 
-    process.env.PINO_PRETTY_PRINT = 'false';
-    process.env.PINO_REDACT_PATHS = 'redactTest';
+    process.env.LOG_PRETTY_PRINT = 'false';
+    process.env.LOG_REDACT_PATHS = 'redactTest';
 
     const stream = sink();
     const log = require('../')({ stream });

--- a/packages/log/tests/index.test.js
+++ b/packages/log/tests/index.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 const once = (emitter, name) =>
     new Promise((resolve, reject) => {
         if (name !== 'error') {
@@ -212,7 +214,9 @@ test('automatically includes a the source location', async () => {
 
     const result = await once(stream, 'data');
 
-    expect(result[sourceLocation]).toEqual({ file: '/tests/index.test.js' });
+    expect(result[sourceLocation]).toEqual({
+        file: path.resolve(process.cwd(), __filename)
+    });
 });
 
 test('can override the source location', async () => {

--- a/packages/log/tests/index.test.js
+++ b/packages/log/tests/index.test.js
@@ -178,3 +178,23 @@ test('includes pid if provided', async () => {
 
     expect(result).toHaveProperty('pid');
 });
+
+test('includes a time formatted to RFC 3339', async () => {
+    expect.assertions(2);
+
+    process.env.LOG_LEVEL = 'info';
+
+    const stream = sink();
+    const log = require('../')({ stream });
+
+    log.info('info-test');
+
+    const result = await once(stream, 'data');
+
+    console.log(result);
+
+    expect(result).toHaveProperty('time');
+    expect(result.time).toMatch(
+        /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/
+    );
+});

--- a/packages/log/tests/index.test.js
+++ b/packages/log/tests/index.test.js
@@ -72,7 +72,7 @@ test('logs to the console', async () => {
     const result = await once(stream, 'data');
 
     expect(result.level).toBe(30);
-    expect(result.msg).toBe('test');
+    expect(result.message).toBe('test');
 });
 
 test('does not log if "LOG_ENABLED" is set to "false"', async () => {
@@ -155,8 +155,6 @@ test('redacts paths specified in "LOG_REDACT_PATHS"', async () => {
 
     expect(result.redactTest).toBe('[Redacted]');
 });
-
-const log = require('@idearium/log')('packages/log/tests/index.test.js');
 
 test('does not include pid by default', async () => {
     expect.assertions(1);

--- a/packages/mongoose/CHANGELOG.md
+++ b/packages/mongoose/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/mongoose
 
-## Unreleased
+## v1.0.1-beta.6
 
 -   Updated @idearium/log to 1.0.0-beta.2.
 

--- a/packages/mongoose/CHANGELOG.md
+++ b/packages/mongoose/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @idearium/mongoose
 
+## Unreleased
+
+-   Updated @idearium/log to 1.0.0-beta.2.
+
 ## v1.0.1-beta.5
 
 -   Update to always include usePushEach.

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/mongoose",
-    "version": "1.0.1-beta.5",
+    "version": "1.0.1-beta.6",
     "description": "Idearium mongoose package.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -7,7 +7,7 @@
     "author": "Allan Chau <allan@idearium.io>",
     "license": "MIT",
     "dependencies": {
-        "@idearium/log": "1.0.0-beta.1",
+        "@idearium/log": "1.0.0-beta.2",
         "mongoose": "^4.11"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5046,7 +5046,7 @@ split2@3.2.2:
   dependencies:
     readable-stream "^3.0.0"
 
-split2@3.1.1, split2@^3.1.1:
+split2@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.1.1.tgz#c51f18f3e06a8c4469aaab487687d8d956160bb6"
   integrity sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,10 +321,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@hapi/bourne@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
+"@hapi/bourne@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-2.0.0.tgz#5bb2193eb685c0007540ca61d166d4e1edaf918d"
+  integrity sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==
 
 "@idearium/eslint-config@3.0.1":
   version "3.0.1"
@@ -702,6 +702,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
@@ -830,6 +837,13 @@ async-value@^1.2.2:
   resolved "https://registry.yarnpkg.com/async-value/-/async-value-1.2.2.tgz#84517a1e7cb6b1a5b5e181fa31be10437b7fb125"
   integrity sha1-hFF6Hny2saW14YH6Mb4QQ3t/sSU=
 
+async@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  integrity sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==
+  dependencies:
+    lodash "^4.14.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -839,6 +853,11 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 await-event@^2.1.0:
   version "2.1.0"
@@ -963,6 +982,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bluebird@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+  integrity sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1020,10 +1044,20 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+bson@~1.0.4:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.9.tgz#12319f8323b1254739b7c6bef8d3e89ae05a2f57"
+  integrity sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer-shims@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+  integrity sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1105,6 +1139,14 @@ chalk@^1.0.0, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -1192,10 +1234,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1256,7 +1310,7 @@ core-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.0.tgz#0fc2d4941cadf80538b030648bb64d230b4da0ce"
   integrity sha512-W2VYNB0nwQQE7tKS7HzXd7r2y/y2SVJl4ga6oH/dnaLFzM0o2lB2P3zCkWj5Wc/zyMYjtgd5Hmhk0ObkQFZOIA==
 
-core-util-is@1.0.2, core-util-is@^1.0.2:
+core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -1333,12 +1387,12 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-dateformat@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
-  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+dateformat@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.1.tgz#c20e7a9ca77d147906b6dc2261a8be0a5bd2173c"
+  integrity sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==
 
-debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1588,6 +1642,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promise@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.2.1.tgz#ec56233868032909207170c39448e24449dd1fc4"
+  integrity sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1936,12 +1995,12 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-redact@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.0.0.tgz#17bb8f5e1f56ecf4a38c8455985e5eab4c478431"
-  integrity sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==
+fast-redact@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.0.1.tgz#d6015b971e933d03529b01333ba7f22c29961e92"
+  integrity sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==
 
-fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.0.7:
+fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
@@ -2065,7 +2124,7 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flatstr@^1.0.12, flatstr@^1.0.9:
+flatstr@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
   integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
@@ -2263,6 +2322,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
@@ -2305,6 +2369,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hooks-fixed@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hooks-fixed/-/hooks-fixed-2.0.2.tgz#20076daa07e77d8a6106883ce3f1722e051140b0"
+  integrity sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ==
 
 hosted-git-info@^2.1.4:
   version "2.8.5"
@@ -2438,7 +2507,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2725,7 +2794,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -3164,6 +3233,11 @@ jmespath@^0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
+joycon@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
+  integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3267,6 +3341,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+kareem@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-1.5.0.tgz#e3e4101d9dcfde299769daf4b4db64d895d17448"
+  integrity sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg=
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3431,6 +3510,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.get@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -3445,6 +3529,11 @@ lodash@4.17.12:
   version "4.17.12"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.12.tgz#a712c74fdc31f7ecb20fe44f157d802d208097ef"
   integrity sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA==
+
+lodash@^4.14.0:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
@@ -3645,10 +3734,66 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
+mongodb-core@2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.18.tgz#4c46139bdf3a1f032ded91db49f38eec01659050"
+  integrity sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA=
+  dependencies:
+    bson "~1.0.4"
+    require_optional "~1.0.0"
+
+mongodb@2.2.34:
+  version "2.2.34"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.34.tgz#a34f59bbeb61754aec432de72c3fe21526a44c1a"
+  integrity sha1-o09Zu+thdUrsQy3nLD/iFSakTBo=
+  dependencies:
+    es6-promise "3.2.1"
+    mongodb-core "2.1.18"
+    readable-stream "2.2.7"
+
+mongoose@^4.11:
+  version "4.13.21"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-4.13.21.tgz#83f4a8461b19aca1b2274feaaaf262b71b6f034d"
+  integrity sha512-0VZtQu1rSUPwUtbb7zh6CymI0nNkVInOIDbtWNlna070qnUO14On8PpSVSwlx3gwmkKL2OkP4ioCj5YHC6trMg==
+  dependencies:
+    async "2.6.0"
+    bson "~1.0.4"
+    hooks-fixed "2.0.2"
+    kareem "1.5.0"
+    lodash.get "4.4.2"
+    mongodb "2.2.34"
+    mpath "0.5.1"
+    mpromise "0.5.5"
+    mquery "2.3.3"
+    ms "2.0.0"
+    muri "1.3.0"
+    regexp-clone "0.0.1"
+    sliced "1.0.1"
+
 monitor-event-loop-delay@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz#b5ab78165a3bb93f2b275c50d01430c7f155d1f7"
   integrity sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q==
+
+mpath@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.5.1.tgz#17131501f1ff9e6e4fbc8ffa875aa7065b5775ab"
+  integrity sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg==
+
+mpromise@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mpromise/-/mpromise-0.5.5.tgz#f5b24259d763acc2257b0a0c8c6d866fd51732e6"
+  integrity sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY=
+
+mquery@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-2.3.3.tgz#221412e5d4e7290ca5582dd16ea8f190a506b518"
+  integrity sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==
+  dependencies:
+    bluebird "3.5.0"
+    debug "2.6.9"
+    regexp-clone "0.0.1"
+    sliced "0.0.5"
 
 mri@1.1.4, mri@^1.1.0:
   version "1.1.4"
@@ -3674,6 +3819,11 @@ multimatch@^3.0.0:
     array-union "^1.0.2"
     arrify "^1.0.1"
     minimatch "^3.0.4"
+
+muri@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/muri/-/muri-1.3.0.tgz#aeccf3db64c56aa7c5b34e00f95b7878527a4721"
+  integrity sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -4112,37 +4262,39 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pino-pretty@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-3.2.1.tgz#db13b793f7074f25051306ee625b6feabae056d9"
-  integrity sha512-PGdcRYw7HCF7ovMhrnepOUmEVh5+tATydRrBICEbP37oRasXV+lo2HA9gg8b7cE7LG6G1OZGVXTZ7MLd946k1Q==
+pino-pretty@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-4.7.1.tgz#499cf185e110399deae731221c899915c811bd1a"
+  integrity sha512-ILE5YBpur88FlZ0cr1BNqVjgG9fOoK+md3peqmcs7AC6oq7SNiaJioIcrykMxfNsuygMYjUJtvAcARRE9aRc9w==
   dependencies:
-    "@hapi/bourne" "^1.3.2"
+    "@hapi/bourne" "^2.0.0"
     args "^5.0.1"
-    chalk "^2.4.2"
-    dateformat "^3.0.3"
-    fast-safe-stringify "^2.0.6"
-    jmespath "^0.15.0"
-    pump "^3.0.0"
-    readable-stream "^3.3.0"
-    split2 "^3.1.1"
-
-pino-std-serializers@^2.3.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz#cb5e3e58c358b26f88969d7e619ae54bdfcc1ae1"
-  integrity sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==
-
-pino@5.13.4:
-  version "5.13.4"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-5.13.4.tgz#52935caaab8d47048deffa315336e8da30d8b96d"
-  integrity sha512-heeg8m8FZY8Nl3nuuD+msJUmhamqoGl7JXoTExh9YpGajzz6LYbVByUqrjbf4sCEMYFsqdcqnTJWiSY660DraQ==
-  dependencies:
-    fast-redact "^2.0.0"
+    chalk "^4.0.0"
+    dateformat "^4.5.1"
     fast-safe-stringify "^2.0.7"
-    flatstr "^1.0.9"
-    pino-std-serializers "^2.3.0"
-    quick-format-unescaped "^3.0.2"
-    sonic-boom "^0.7.5"
+    jmespath "^0.15.0"
+    joycon "^2.2.5"
+    pump "^3.0.0"
+    readable-stream "^3.6.0"
+    split2 "^3.1.1"
+    strip-json-comments "^3.1.1"
+
+pino-std-serializers@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
+  integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@6.11.3:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.11.3.tgz#0c02eec6029d25e6794fdb6bbea367247d74bc29"
+  integrity sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -4219,6 +4371,11 @@ pretty-quick@1.11.1:
     mri "^1.1.0"
     multimatch "^3.0.0"
 
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -4265,10 +4422,10 @@ querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-quick-format-unescaped@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz#fb3e468ac64c01d22305806c39f121ddac0d1fb9"
-  integrity sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==
+quick-format-unescaped@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz#6d6b66b8207aa2b35eef12be1421bb24c428f652"
+  integrity sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==
 
 r7insight_node@1.8.3:
   version "1.8.3"
@@ -4328,7 +4485,20 @@ read-pkg@^5.1.1, read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^3.0.0, readable-stream@^3.0.6, readable-stream@^3.3.0, readable-stream@^3.4.0:
+readable-stream@2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.7.tgz#07057acbe2467b22042d36f98c5ad507054e95b1"
+  integrity sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=
+  dependencies:
+    buffer-shims "~1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~1.0.0"
+    util-deprecate "~1.0.1"
+
+readable-stream@^3.0.0, readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -4371,6 +4541,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp-clone@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
+  integrity sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -4463,12 +4638,25 @@ require-main-filename@2.0.0, require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require_optional@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -4565,7 +4753,7 @@ rxjs@^6.3.3, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4612,7 +4800,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4720,6 +4908,16 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+sliced@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-0.0.5.tgz#5edc044ca4eb6f7816d50ba2fc63e25d8fe4707f"
+  integrity sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=
+
+sliced@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+  integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -4757,11 +4955,12 @@ socket-location@^1.0.0:
   dependencies:
     await-event "^2.1.0"
 
-sonic-boom@^0.7.5:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-0.7.6.tgz#c42df6df884a6a3d54fa7a45b11e4e2196818d45"
-  integrity sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==
+sonic-boom@^1.0.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.4.1.tgz#d35d6a74076624f12e6f917ade7b9d75e918f53e"
+  integrity sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==
   dependencies:
+    atomic-sleep "^1.0.0"
     flatstr "^1.0.12"
 
 source-map-resolve@^0.5.0:
@@ -4831,7 +5030,14 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@3.1.1, split2@^3.1.1:
+split2@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
+  integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
+  dependencies:
+    readable-stream "^3.0.0"
+
+split2@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.1.1.tgz#c51f18f3e06a8c4469aaab487687d8d956160bb6"
   integrity sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==
@@ -4982,6 +5188,13 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringify-object@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
@@ -5037,6 +5250,11 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -5055,6 +5273,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -5266,7 +5491,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,15 @@
     eslint "^5.0.1"
     eslint-plugin-eslint-comments "^3.0.0"
 
+"@idearium/log@1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@idearium/log/-/log-1.0.0-beta.2.tgz#99886552c881b84b6d41b8b711fbb29bdd5c0822"
+  integrity sha512-zxQdtAq8ysxMY+g8ui9ink15rfniuMAmV5vs+uYylh6YVi3/waLfzQIhsk/Pnxn+a39V87ep1KzFvz+FAe55KA==
+  dependencies:
+    pino "6.11.3"
+    pino-pretty "4.7.1"
+    require-main-filename "2.0.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"


### PR DESCRIPTION
This PR removes `insightops` from @idearium/log, and creates a new @idearium/log-insightops.

It also includes the following updates to @idearium/log:

- Dependency upgrades.
- Pretty printing now needs to be explicitly enabled with `LOG_PRETTY_PRINT` set to `'true'`.
- All `PINO_` environment variables have been renamed to `LOG_`.
- Log structure has been updated to support [GCP Structured Logging](https://cloud.google.com/logging/docs/structured-logging).
- The file from which the log instance was created is now stored in the log output it produces.

The following changes have been made to the InsightOps transport:

- Deprecated `LOG_REMOTE` (if you use it, it's always on).

## Tasks

- N/A

## Related PRs

- N/A

## Testing

- [x] Check deployment steps.
- [x] Review the documentation (run docsaurus locally to test).
- [x] Review the updated tests.
- [x] Review the log structure matches [GCP structured logging](https://cloud.google.com/logging/docs/structured-logging) requirements (see note below).
- [x] Integrate into a project and test the logs work properly on GCP.

**Please note:** The following GCP structured logging fields haven't been included in the default setup:
- logging.googleapis.com/insertId
- logging.googleapis.com/labels
- logging.googleapis.com/operation
- logging.googleapis.com/spanId
- logging.googleapis.com/trace
- logging.googleapis.com/trace_sampled

## Deployment

- [x] Version bump @idearium/log to v1.0.0 and release.
- [x] Version bump @idearium/log-insightops to v1.0.0 and release.