### PR TITLE
Doc typos

### DIFF
--- a/docusaurus/docs/about.md
+++ b/docusaurus/docs/about.md
@@ -9,7 +9,7 @@ Idearium Lib is group of es6 packages built by Idearium for Idearium. We use the
 
 ## Monorepo
 
-The [Idearium Lib repository](https://github.com/idearium/idearium-lib) is a monorepo. It features all of our [packages](https://github.com/idearium/idearium-lib/tree/monorepo/packages). We use Yarn's workspaces feature to make it easy to manage multiple packages in one Git repository.
+The [Idearium Lib repository](https://github.com/idearium/idearium-lib) is a monorepo. It features all of our [packages](https://github.com/idearium/idearium-lib/tree/master/packages). We use Yarn's workspaces feature to make it easy to manage multiple packages in one Git repository.
 
 ## Versioning
 
@@ -23,10 +23,10 @@ You can find all of [our releases on GitHub](https://github.com/idearium/ideariu
 
 We use GitHub Actions and workflows to test our packages and publish them at the appropriate time.
 
-Each package has a [workflow](https://github.com/idearium/idearium-lib/tree/monorepo/.github/workflows) to handle the idiosyncrasies of each particular package.
+Each package has a [workflow](https://github.com/idearium/idearium-lib/tree/master/.github/workflows) to handle the idiosyncrasies of each particular package.
 
 You can find all of [our releases on GitHub](https://github.com/idearium/idearium-lib/releases).
 
 ## Docs
 
-The Idearium Lib docs are auto deployed whenever there is a change made and the PR is merged into the main branch (feature-monorepo).
+The Idearium Lib docs are auto deployed whenever there is a change made and the PR is merged into the main branch (master).

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -12,7 +12,7 @@ module.exports = {
             {
                 docs: {
                     editUrl:
-                        'https://github.com/idearium/idearium-lib/tree/feature-monorepo/docusaurus/',
+                        'https://github.com/idearium/idearium-lib/tree/master/docusaurus/',
                     sidebarPath: require.resolve('./sidebars.js')
                 },
                 theme: {


### PR DESCRIPTION
This PR removes some references to the old monorepo branch from the docs.

## Related PRs

- #84 

## Verification and testing

### Testing

- [ ] Run the docs locally and check the links in about.md have been updated.
- [ ] Check the edit button goes to the correct page.
