### PR TITLE
Request log formatting resilience

### DIFF
--- a/packages/log-structured/CHANGELOG.md
+++ b/packages/log-structured/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   An issue when formatting a request log that has no headers.
+
 ## v1.0.3 - 2021-10-26
 
 ### Add

--- a/packages/log-structured/CHANGELOG.md
+++ b/packages/log-structured/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.4 - 2022-05-10
+
 ### Fixed
 
 -   An issue when formatting a request log that has no headers.

--- a/packages/log-structured/index.js
+++ b/packages/log-structured/index.js
@@ -12,19 +12,19 @@ const write = (callback, line) => {
 
 const createHttpRequest = (req, res) => ({
     protocol: req.protocol,
-    referer: req.headers.referer || '',
+    referer: (req.headers && req.headers.referer) || '',
     remoteIp:
-        req.headers['x-forwarded-for'] ||
+        (req.headers && req.headers['x-forwarded-for']) ||
         // This is for < v13
         req.remoteIp ||
         // This is for > v14
         '',
     requestMethod: req.method,
-    requestSize: req.headers['content-length'] || 0,
+    requestSize: (req.headers && req.headers['content-length']) || 0,
     requestUrl: req.url,
     responseSize: res.size || 0,
     status: res.statusCode,
-    userAgent: req.headers['user-agent'] || '',
+    userAgent: (req.headers && req.headers['user-agent']) || '',
 });
 
 const transformOpentelemetry = (log) => {

--- a/packages/log-structured/package.json
+++ b/packages/log-structured/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/log-structured",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Idearium logger structured logging formatter",
     "repository": "https://github.com/idearium/idearium-lib",
     "author": "Scott Mebberson <scott@idearium.io>",

--- a/packages/log-structured/tests/structured.test.js
+++ b/packages/log-structured/tests/structured.test.js
@@ -138,7 +138,7 @@ test('logs non-http json without mutation', async () => {
 });
 
 test('logs req when logging http requests', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
     const stream = structured();
     const log = middleware(stream);
@@ -150,8 +150,25 @@ test('logs req when logging http requests', async () => {
     const line = JSON.parse(result.toString());
 
     expect(line).toHaveProperty('req');
+    expect(line.req).toHaveProperty('headers');
 
     server.close();
+});
+
+test('logs req even without headers', async () => {
+    expect.assertions(2);
+
+    const stream = structured();
+
+    stream.write(
+        '{"level":30,"severity":"INFO","time":"2021-11-25T02:51:57.024Z","req":{"id":1,"method":"GET","protocol":"http/1.1","remoteAddress":"127.0.0.1","remoteIp":"127.0.0.1","remotePort":65404,"url":"/"},"spanId":"XYZ","traceId":"ABC123","res":{"headers":{"x-powered-by":"Express"},"size":11,"statusCode":200},"responseTime":0.001,"message":"request completed"}'
+    );
+
+    const result = await once(stream, 'data');
+    const line = JSON.parse(result.toString());
+
+    expect(line).toHaveProperty('req');
+    expect(line.req).not.toHaveProperty('headers');
 });
 
 test('logs res when logging http requests', async () => {


### PR DESCRIPTION
This PR fixes an issue that occurs when formatting a request log that has no headers.

## Testing

- [ ] Review the code.
- [ ] Review the new test addresses the issue.