### PR TITLE
Multiple states for react-state-router

### DIFF
--- a/docusaurus/docs/react-state-router.md
+++ b/docusaurus/docs/react-state-router.md
@@ -52,3 +52,25 @@ export default StateRouterComponent;
 ```
 
 The state router will now automatically display the component when the `when` attribute matches the xstate state.
+
+### Multiple states
+
+You can also pass an array of states to the `when` attribute to display the component when multiple states match.
+
+```js
+import StateRouter from '@idearium/react-state-router';
+import ReactContext from 'context/reactContext';
+import Step1 from 'steps/step1';
+import Step2 from 'steps/step2';
+import Step3 from 'steps/step3';
+
+const StateRouterComponent = () => (
+    <StateRouter context={ReactContext}>
+        <Step1 when={['A', 'Z']} />
+        <Step2 when="B" />
+        <Step3 when="C" />
+    </StateRouter>
+);
+
+export default StateRouterComponent;
+```

--- a/packages/react-state-router/CHANGELOG.md
+++ b/packages/react-state-router/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+## v1.0.1 - 2023-05-15
+
 ### Added
 
 -   Added support for passing arrays as the `when` attribute to allow one component to be displayed for multiple states.
 
-## 1.0.0 - 2022-12-15
+## v1.0.0 - 2022-12-15
 
 -   Initial release.

--- a/packages/react-state-router/CHANGELOG.md
+++ b/packages/react-state-router/CHANGELOG.md
@@ -1,3 +1,11 @@
 # @idearium/react-state-router
 
 ## Unreleased
+
+### Added
+
+-   Added support for passing arrays as the `when` attribute to allow one component to be displayed for multiple states.
+
+## 1.0.0 - 2022-12-15
+
+-   Initial release.

--- a/packages/react-state-router/CHANGELOG.md
+++ b/packages/react-state-router/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-## v1.0.1 - 2023-05-15
+### Added
+
+-   Added type set to module in package.json.
+
+## v1.0.1-beta.1 - 2023-05-15
 
 ### Added
 

--- a/packages/react-state-router/CHANGELOG.md
+++ b/packages/react-state-router/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.1-beta.1 - 2023-05-16
+
 ### Added
 
 -   Added type set to module in package.json.

--- a/packages/react-state-router/index.js
+++ b/packages/react-state-router/index.js
@@ -24,11 +24,19 @@ const StateRouter = ({ children, context }) => {
             serviceState && serviceState.matches
                 ? kids
                       .filter((child) => isValidElement(child))
-                      .filter((view) =>
-                          view.props.when
-                              ? serviceState.matches(view.props.when)
-                              : true
-                      )
+                      .filter((view) => {
+                          if (!view.props.when) {
+                              return true;
+                          }
+
+                          let when = view.props.when;
+
+                          if (!Array.isArray(when)) {
+                              when = [when];
+                          }
+
+                          return when.some(serviceState.matches);
+                      })
                 : [],
         [kids, serviceState]
     );
@@ -39,10 +47,10 @@ const StateRouter = ({ children, context }) => {
                   return cloneElement(
                       view,
                       {
-                          service,
                           context: serviceState.context,
                           key: index,
                           send: service.send,
+                          service,
                       },
                       null
                   );

--- a/packages/react-state-router/package.json
+++ b/packages/react-state-router/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/react-state-router",
-    "version": "1.0.1-beta.1",
+    "version": "1.0.1-beta.2",
     "description": "React state router component for XState",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/react-state-router/package.json
+++ b/packages/react-state-router/package.json
@@ -9,6 +9,7 @@
         "Scott Mebberson <scott@idearium.io>"
     ],
     "license": "MIT",
+    "type": "module",
     "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18",

--- a/packages/react-state-router/package.json
+++ b/packages/react-state-router/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/react-state-router",
-    "version": "1.0.0",
+    "version": "1.0.1-beta.1",
     "description": "React state router component for XState",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,11 +415,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@idearium/certs@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@idearium/certs/-/certs-2.0.0.tgz#b60c06eb3dd006b59ab662e74506a83e2488610f"
-  integrity sha512-/KiOfxV7qDqgzD1iunEjSr/SwL9w0o2l7YmHysoPded1SC5sn615JgbSIO2VwhkZMOXA6qgPzHhcyCG50YhZ/w==
-
 "@idearium/eslint-config@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@idearium/eslint-config/-/eslint-config-4.0.0.tgz#c51d2899e32b0e296d8886589030d64c4d274509"
@@ -448,10 +443,10 @@
     pino "6.13.2"
     pino-pretty "4.7.1"
 
-"@idearium/log@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@idearium/log/-/log-2.1.0.tgz#8de1aa90bbe80fe1655ecce76d92f02847534ecc"
-  integrity sha512-zvQtYOKCbd4WDETBKcGH+dnL3ZchULFN5DRp54IJezjKv99tsyWZab3SBhRdw05WMDb2WyO8ITEPWPh4rNu6Iw==
+"@idearium/log@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@idearium/log/-/log-2.0.2.tgz#68b9df142ce7bac26ceb92f58e1c11fb48b5ccbe"
+  integrity sha512-skoUN+w1gRdfMHHdDuAnuo6woeOkzoqfuDkdSI1yH9B6IXh0cw5bnfcAx5Wqi0253flwXBA4lvX1xu7b1XtzqA==
   dependencies:
     pino "6.13.2"
     pino-pretty "4.7.1"


### PR DESCRIPTION
This PR updates @idearium/react-state-router to support being passed an array in the `when` parameter so that one component can be displayed for multiple states.

This allows a view to show a loading state, while the machine invokes a service to load data.

## Testing

These are the steps to demonstrate the solution being solved; they typically include steps to update the repository to a new state containing the code that fixes the problem.

- [ ] A list of steps to demonstrate the problem.
