### PR TITLE
Fetch updates

### DIFF
--- a/packages/apm/package.json
+++ b/packages/apm/package.json
@@ -7,6 +7,6 @@
     "author": "Allan Chau <allan@idearium.io>",
     "license": "MIT",
     "dependencies": {
-        "elastic-apm-node": "3.41.0"
+        "elastic-apm-node": "4.1.0"
     }
 }

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @idearium/fetch
 
+## v3.0.0-beta.1
+
+### Removed
+
+-   Removed isomorphic-fetch.
+-   Minimum Node.js version is now v18.0.0.
+
 ## v2.0.4
 
 ### Fixed

--- a/packages/fetch/index.js
+++ b/packages/fetch/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const fetch = require('isomorphic-fetch');
-
 const parseBody = (response) => {
     if (
         response.headers &&

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/fetch",
-    "version": "2.0.4",
+    "version": "3.0.0-beta.1",
     "description": "A package to make fetching trivial.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",
@@ -12,10 +12,8 @@
     "scripts": {
         "test": "jest"
     },
-    "dependencies": {
-        "isomorphic-fetch": "3.0.0"
-    },
+    "dependencies": {},
     "devDependencies": {
-        "fetch-mock-jest": "^1.5.1"
+        "fetch-mock-jest": "1.5.1"
     }
 }

--- a/packages/fetch/tests/index.test.js
+++ b/packages/fetch/tests/index.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
-jest.mock('isomorphic-fetch', () => require('fetch-mock-jest').sandbox());
-
-const fetchMock = require('isomorphic-fetch');
+const fetchMock = require('fetch-mock-jest');
 const fetchApi = require('../');
 
 const testUrl = 'https://www.idearium.io/';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3493,7 +3493,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-mock-jest@^1.5.1:
+fetch-mock-jest@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz#0e13df990d286d9239e284f12b279ed509bf53cd"
   integrity sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==
@@ -4354,14 +4354,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-isomorphic-fetch@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -5751,7 +5743,7 @@ nib@~1.1.2:
   dependencies:
     stylus "0.54.5"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.8.tgz#a68d30b162bc1d8fd71a367e81b997e1f4d4937e"
   integrity sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==
@@ -7801,11 +7793,6 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-whatwg-fetch@^3.4.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR removes the isomorphic-fetch dependency.

## Notes

- I am encountering this issue in Node 20.
- fetch has been stable since Node 18 so this shouldn't cause any issues.

## Verification and testing

### Testing

- [ ] Import `v3.0.0-beta.1` of this package and check it works as it did before.
