### PR TITLE
Convert @idearium/safe-promise to an ESM

### DIFF
--- a/docusaurus/docs/safe-promise.md
+++ b/docusaurus/docs/safe-promise.md
@@ -23,10 +23,10 @@ $ yarn add -E @idearium/safe-promise@beta
 
 ### safePromise
 
-To use `safePromise`, require it from `@idearium/safe-promise`.
+To use `safePromise`, import it from `@idearium/safe-promise`.
 
 ```js
-const safePromise = require('@idearium/safe-promise');
+import { safePromise } from '@idearium/safe-promise';
 ```
 
 This will take a promise and always use `resolve` to return a result in the format `[err, result]`.

--- a/packages/safe-promise/.eslintrc.json
+++ b/packages/safe-promise/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": ["../.eslintrc.json"],
+    "parserOptions": {
+        "sourceType": "module"
+    }
+}

--- a/packages/safe-promise/CHANGELOG.md
+++ b/packages/safe-promise/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @idearium/safe-promise
 
-## v2.0.0-beta.1
+## v2.0.0
 
 -   Converted to ESM.
 

--- a/packages/safe-promise/CHANGELOG.md
+++ b/packages/safe-promise/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @idearium/safe-promise
 
+## v2.0.0-beta.1
+
+-   Converted to ESM.
+
 ## v1.0.0
 
 -   First version of the package.

--- a/packages/safe-promise/index.js
+++ b/packages/safe-promise/index.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const safePromise = (p) =>
+export const safePromise = (p) =>
     new Promise((resolve) => {
         p.then((result) => resolve([null, result])).catch((err) =>
             resolve([err])
         );
     });
-
-module.exports = safePromise;

--- a/packages/safe-promise/jest.config.js
+++ b/packages/safe-promise/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+    transform: {},
+};

--- a/packages/safe-promise/package.json
+++ b/packages/safe-promise/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/safe-promise",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "description": "A package to make promises safe.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",

--- a/packages/safe-promise/package.json
+++ b/packages/safe-promise/package.json
@@ -1,12 +1,13 @@
 {
     "name": "@idearium/safe-promise",
-    "version": "1.0.0",
-    "description": "A packages to make promises safe.",
+    "version": "2.0.0-beta.1",
+    "description": "A package to make promises safe.",
     "main": "index.js",
     "repository": "https://github.com/idearium/idearium-lib",
     "author": "Scott Mebberson <scott@idearium.io>",
     "license": "MIT",
     "scripts": {
-        "test": "jest"
-    }
+        "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js"
+    },
+    "type": "module"
 }

--- a/packages/safe-promise/tests/safe-promise.test.js
+++ b/packages/safe-promise/tests/safe-promise.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const safePromise = require('..');
+import { safePromise } from '../index.js';
 
 describe('safePromise', () => {
     it('is a function', () => {
@@ -12,7 +12,7 @@ describe('safePromise', () => {
 
         await expect(safePromise(Promise.resolve('test'))).resolves.toEqual([
             null,
-            'test'
+            'test',
         ]);
     });
 
@@ -22,7 +22,7 @@ describe('safePromise', () => {
         const error = new Error('test');
 
         await expect(safePromise(Promise.reject(error))).resolves.toEqual([
-            error
+            error,
         ]);
     });
 });


### PR DESCRIPTION
This PR turns @idearium/safe-promise into an ESM.

## Testing

Do this on Next.js using ESM.

- [ ] Install the latest version with `yarn add -E @idearium/safe-promise@beta`.
- [ ] Ensure v2.0.0-beta.1 is installed.
- [ ] Import the package with `import { safePromise } from '@idearium/safe-promise';`.
- [ ] Write some code that uses the package and make sure it works.

## Deployment

- [x] Version bump.
- [x] Do a `v2.0.0` release on GitHub.
